### PR TITLE
Investigate dataset deletion internal server error

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -181,7 +181,8 @@ export class DatasetAPI {
    * Удалить датасет с сервера
    */
   static async deleteDataset(id: string): Promise<{ success: boolean; message: string }> {
-    const response = await fetchWithCreds(`${API_BASE_URL}/datasets/${id}`, {
+    const safeId = encodeURIComponent(id.toUpperCase());
+    const response = await fetchWithCreds(`${API_BASE_URL}/datasets/${safeId}`, {
       method: 'DELETE',
     });
     


### PR DESCRIPTION
Fixes 500 error on dataset deletion by updating backend to correctly resolve and remove dataset files (including legacy formats) and frontend to send normalized ID.

The previous backend implementation for deleting datasets expected a simple `id.json` filename, which failed when the actual files on disk had legacy names like `TICKER_YYYY-MM-DD.json`. This led to a 500 error because the file to be deleted was not found. The fix ensures the backend uses the `resolveDatasetFilePathById` helper to find the correct file and also cleans up any related legacy files. The frontend change ensures the ID is sent consistently.

---
<a href="https://cursor.com/background-agent?bcId=bc-4bf87233-79bb-4be7-9304-ade4342366b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4bf87233-79bb-4be7-9304-ade4342366b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

