### PR TITLE
Improve dark theme and move toggle

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -130,18 +130,23 @@ export default function App() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-800">
-      <header className="border-b bg-white/60 backdrop-blur sticky top-0 z-20">
+    <div className="min-h-screen bg-gray-50 text-gray-800 dark:text-gray-100">
+      {/* Floating theme toggle in top-right corner */}
+      <div className="fixed top-3 right-3 z-50">
+        <ThemeToggle />
+      </div>
+
+      <header className="border-b bg-white/60 backdrop-blur sticky top-0 z-20 dark:bg-slate-900/60 dark:border-slate-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <ThemeToggle />
+            {/* Removed ThemeToggle from here to place it in the top-right corner */}
             <h1 className="text-lg font-semibold tracking-tight">Trading strategies</h1>
             {apiBuildId && (
-              <span className="text-xs text-gray-500">API build: {apiBuildId}</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">API build: {apiBuildId}</span>
             )}
           </div>
           <div className="flex items-center gap-2">
-            <a className="inline-flex items-center gap-2 text-sm hover:text-indigo-600" href="#settings">
+            <a className="inline-flex items-center gap-2 text-sm hover:text-indigo-600 dark:hover:text-indigo-400" href="#settings">
               <Settings size={16} />
               Settings
             </a>
@@ -157,7 +162,9 @@ export default function App() {
                 key={t.id}
                 disabled={!t.enabled}
                 onClick={() => setActiveTab(t.id)}
-                className={`px-3 py-1 rounded text-sm border ${activeTab === t.id ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white hover:bg-gray-50 text-gray-700 border-gray-200'}`}
+                className={`${activeTab === t.id
+                  ? 'px-3 py-1 rounded text-sm border bg-indigo-600 text-white border-indigo-600 dark:bg-indigo-500 dark:border-indigo-500'
+                  : 'px-3 py-1 rounded text-sm border bg-white hover:bg-gray-50 text-gray-700 border-gray-200 dark:bg-slate-800 dark:hover:bg-slate-700 dark:text-gray-200 dark:border-slate-700'}`}
               >
                 {t.label}
               </button>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -52,7 +52,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={cycle}
-      className="inline-flex items-center gap-2 px-3 py-2 rounded-full border border-gray-200 text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-800"
+      className="inline-flex items-center gap-2 px-3 py-2 rounded-full border border-gray-200 text-gray-700 hover:text-gray-900 hover:bg-gray-100 bg-white/80 backdrop-blur-sm shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:text-gray-200 dark:hover:text-white dark:hover:bg-slate-700/80 dark:bg-slate-800/80 dark:backdrop-blur-sm dark:shadow-sm dark:focus-visible:ring-offset-slate-900 transition-colors"
       title={`Тема: ${label}`}
       aria-label={`Тема: ${label}`}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -604,9 +604,18 @@ html, body, #root {
 .dark body { 
   background-color: var(--color-bg-dark); 
   color: var(--color-text-dark);
-  background-image: radial-gradient(1200px 600px at 100% -10%, rgba(59,130,246,0.08), transparent),
-                    radial-gradient(800px 400px at -10% 100%, rgba(16,185,129,0.08), transparent);
+  background-image:
+    radial-gradient(1200px 600px at 100% -10%, rgba(59,130,246,0.08), transparent),
+    radial-gradient(800px 400px at -10% 100%, rgba(16,185,129,0.08), transparent);
   background-attachment: fixed;
+}
+
+/* Glass panel utility */
+.dark .glass-panel {
+  background-color: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(51, 65, 85, 0.6);
+  box-shadow: 0 10px 25px rgba(0,0,0,0.45), 0 2px 6px rgba(0,0,0,0.3);
+  backdrop-filter: blur(8px);
 }
 
 /* Common utility overrides for legacy light classes used in components */
@@ -623,6 +632,13 @@ html, body, #root {
 
 /* Cards and panels looking more elevated in dark */
 .dark .shadow { box-shadow: 0 10px 25px rgba(0,0,0,0.45), 0 2px 6px rgba(0,0,0,0.3) !important; }
+
+/* Header refinement */
+.dark header {
+  background-color: rgba(15, 23, 42, 0.6) !important;
+  border-bottom-color: #0b1220 !important;
+  backdrop-filter: blur(8px);
+}
 
 /* Inputs */
 .dark input[type="text"],


### PR DESCRIPTION
Relocate theme toggle to top-right corner and enhance dark theme aesthetics for header, tabs, and toggle button.

---
<a href="https://cursor.com/background-agent?bcId=bc-b81d6754-895c-438b-a73d-74a858c29af0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b81d6754-895c-438b-a73d-74a858c29af0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

