### PR TITLE
Fix refresh icon rotation animation

### DIFF
--- a/src/components/DatasetLibrary.tsx
+++ b/src/components/DatasetLibrary.tsx
@@ -270,11 +270,11 @@ function DatasetCard({ dataset, isActive, onLoad, onDelete, onExport, onRefresh,
         <div className="flex items-center gap-2 ml-4">
           <button
             onClick={onRefresh}
-            className={`p-2 text-gray-400 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-transparent rounded transition-colors ${refreshing ? 'animate-spin' : ''}`}
+            className="p-2 text-gray-400 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-transparent rounded transition-colors"
             title="Обновить датасет"
             aria-label="Обновить датасет"
           >
-            <RefreshCw className="w-4 h-4" />
+            <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin origin-center' : ''}`} />
           </button>
           <button
             onClick={onExport}


### PR DESCRIPTION
Fixes the refresh icon spinning off-center by moving the animation class to the SVG and adding `origin-center`.

---
<a href="https://cursor.com/background-agent?bcId=bc-dca31b08-0ef2-44c1-8b63-f30b164bbed6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dca31b08-0ef2-44c1-8b63-f30b164bbed6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

