### PR TITLE
Debug ticker selection error on results page

### DIFF
--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -530,15 +530,15 @@ export function Results() {
                 })()}
               />
             </div>
-            <TradingChart />
+            <TradingChart data={marketData} trades={trades} splits={currentSplits} />
           </div>
         </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 space-y-6">
-          <EquityChart />
-          <TradeDrawdownChart />
+          <EquityChart equity={equity} />
+          <TradeDrawdownChart trades={trades} initialCapital={Number(currentStrategy?.riskManagement?.initialCapital ?? 10000)} />
         </div>
 
         <div className="space-y-4">


### PR DESCRIPTION
Pass required props to chart components to fix `TypeError: Cannot read properties of undefined` on the results page.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f194838-82f9-46d3-bcd1-5a46179fc703">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f194838-82f9-46d3-bcd1-5a46179fc703">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

