### PR TITLE
Update financial results page layout and add new tabs

### DIFF
--- a/src/components/ProfitFactorChart.tsx
+++ b/src/components/ProfitFactorChart.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import { createChart, type IChartApi, type ISeriesApi, type UTCTimestamp } from 'lightweight-charts';
+import type { Trade } from '../types';
+
+interface ProfitFactorChartProps {
+	trades: Trade[];
+}
+
+export function ProfitFactorChart({ trades }: ProfitFactorChartProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const chartRef = useRef<IChartApi | null>(null);
+	const [isDark, setIsDark] = useState<boolean>(() => typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false);
+
+	useEffect(() => {
+		const onTheme = (e: any) => {
+			const dark = !!(e?.detail?.effectiveDark ?? document.documentElement.classList.contains('dark'));
+			setIsDark(dark);
+		};
+		window.addEventListener('themechange', onTheme);
+		return () => window.removeEventListener('themechange', onTheme);
+	}, []);
+
+	useEffect(() => {
+		if (!containerRef.current || !trades.length) return;
+
+		if (chartRef.current) {
+			try { chartRef.current.remove(); } catch {}
+			chartRef.current = null;
+		}
+
+		const bg = isDark ? '#0b1220' : '#ffffff';
+		const text = isDark ? '#e5e7eb' : '#1f2937';
+		const grid = isDark ? '#1f2937' : '#eef2ff';
+		const border = isDark ? '#374151' : '#e5e7eb';
+
+		const chart = createChart(containerRef.current, {
+			width: containerRef.current.clientWidth,
+			height: Math.max(containerRef.current.clientHeight || 0, 360),
+			layout: { background: { color: bg }, textColor: text },
+			grid: { vertLines: { color: grid }, horzLines: { color: grid } },
+			rightPriceScale: { borderColor: border },
+			timeScale: { borderColor: border, timeVisible: true, secondsVisible: false },
+			crosshair: { mode: 1 },
+		});
+		chartRef.current = chart;
+
+		const series: ISeriesApi<'Histogram'> = chart.addHistogramSeries({
+			color: isDark ? 'rgba(156,163,175,0.5)' : 'rgba(107,114,128,0.5)',
+			base: 0,
+			priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
+		});
+
+		const data = trades.map((t) => ({
+			time: Math.floor(t.exitDate.getTime() / 1000) as UTCTimestamp,
+			value: t.pnlPercent ?? 0,
+			color: (t.pnlPercent ?? 0) >= 0 ? (isDark ? 'rgba(16,185,129,0.7)' : 'rgba(16,185,129,0.9)') : (isDark ? 'rgba(239,68,68,0.7)' : 'rgba(239,68,68,0.9)'),
+		}));
+		series.setData(data);
+
+		const zeroLine = chart.addLineSeries({ color: isDark ? '#9ca3af' : '#9ca3af', lineWidth: 1, lineStyle: 2, title: '0%' });
+		zeroLine.setData(data.map(d => ({ time: d.time, value: 0 })));
+
+		const handleResize = () => {
+			if (!containerRef.current || !chart) return;
+			chart.applyOptions({ width: containerRef.current.clientWidth, height: Math.max(containerRef.current.clientHeight || 0, 360) });
+		};
+		window.addEventListener('resize', handleResize);
+		return () => {
+			window.removeEventListener('resize', handleResize);
+			try { chart.remove(); } catch {}
+		};
+	}, [trades, isDark]);
+
+	if (!trades.length) {
+		return <div className="text-gray-500">Нет данных по сделкам</div>;
+	}
+
+	// PF summary computed by $ PnL values
+	const grossProfit = trades.filter(t => (t.pnl ?? 0) > 0).reduce((s, t) => s + (t.pnl ?? 0), 0);
+	const grossLoss = Math.abs(trades.filter(t => (t.pnl ?? 0) < 0).reduce((s, t) => s + (t.pnl ?? 0), 0));
+	const profitFactor = grossLoss > 0 ? (grossProfit / grossLoss) : Infinity;
+
+	return (
+		<div className="w-full h-full">
+			<div className="flex flex-wrap gap-4 mb-4 text-sm">
+				<div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+					<span className="text-gray-700 dark:text-gray-200">Profit Factor: {Number.isFinite(profitFactor) ? profitFactor.toFixed(2) : '∞'}</span>
+				</div>
+				<div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+					<span className="text-gray-700 dark:text-gray-200">Средний PnL, %: {(trades.reduce((s, t) => s + (t.pnlPercent ?? 0), 0) / trades.length).toFixed(2)}%</span>
+				</div>
+			</div>
+			<div ref={containerRef} className="w-full h-[360px] min-h-0 overflow-hidden" />
+		</div>
+	);
+}

--- a/src/components/TradeDrawdownChart.tsx
+++ b/src/components/TradeDrawdownChart.tsx
@@ -194,9 +194,6 @@ export function TradeDrawdownChart({ trades, initialCapital }: TradeDrawdownChar
         <div className="bg-gray-50 px-3 py-2 rounded dark:bg-gray-800 dark:text-gray-200">
           <span className="text-gray-600 dark:text-gray-200">Частота просадок: {drawdownFrequency.toFixed(1)}%</span>
         </div>
-        <div className="bg-blue-50 px-3 py-2 rounded dark:bg-blue-950/30 dark:text-blue-200">
-          <span className="text-blue-600 dark:text-blue-200">Итоговый капитал: ${runningCapital.toFixed(2)}</span>
-        </div>
       </div>
       
       {/* Chart Container */}

--- a/src/components/TradeDurationChart.tsx
+++ b/src/components/TradeDurationChart.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react';
+import { createChart, type IChartApi, type ISeriesApi, type UTCTimestamp } from 'lightweight-charts';
+import type { Trade } from '../types';
+
+interface TradeDurationChartProps {
+	trades: Trade[];
+}
+
+export function TradeDurationChart({ trades }: TradeDurationChartProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const chartRef = useRef<IChartApi | null>(null);
+	const [isDark, setIsDark] = useState<boolean>(() => typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false);
+
+	useEffect(() => {
+		const onTheme = (e: any) => {
+			const dark = !!(e?.detail?.effectiveDark ?? document.documentElement.classList.contains('dark'));
+			setIsDark(dark);
+		};
+		window.addEventListener('themechange', onTheme);
+		return () => window.removeEventListener('themechange', onTheme);
+	}, []);
+
+	useEffect(() => {
+		if (!containerRef.current || !trades.length) return;
+
+		if (chartRef.current) {
+			try { chartRef.current.remove(); } catch {}
+			chartRef.current = null;
+		}
+
+		const bg = isDark ? '#0b1220' : '#ffffff';
+		const text = isDark ? '#e5e7eb' : '#1f2937';
+		const grid = isDark ? '#1f2937' : '#eef2ff';
+		const border = isDark ? '#374151' : '#e5e7eb';
+
+		const chart = createChart(containerRef.current, {
+			width: containerRef.current.clientWidth,
+			height: Math.max(containerRef.current.clientHeight || 0, 360),
+			layout: { background: { color: bg }, textColor: text },
+			grid: { vertLines: { color: grid }, horzLines: { color: grid } },
+			rightPriceScale: { borderColor: border },
+			timeScale: { borderColor: border, timeVisible: true, secondsVisible: false },
+			crosshair: { mode: 1 },
+		});
+		chartRef.current = chart;
+
+		const series: ISeriesApi<'Histogram'> = chart.addHistogramSeries({
+			color: isDark ? 'rgba(59,130,246,0.7)' : 'rgba(59,130,246,0.9)',
+			base: 0,
+			priceFormat: { type: 'price', precision: 0, minMove: 1 },
+		});
+
+		const data = trades.map((t) => ({
+			time: Math.floor(t.exitDate.getTime() / 1000) as UTCTimestamp,
+			value: Math.round(t.duration ?? 0),
+			color: isDark ? 'rgba(59,130,246,0.7)' : 'rgba(59,130,246,0.9)'
+		}));
+		series.setData(data);
+
+		const avg = data.reduce((s, d) => s + (d.value || 0), 0) / Math.max(1, data.length);
+		try { series.createPriceLine({ price: avg, color: '#9CA3AF', lineWidth: 1, lineStyle: 2, axisLabelVisible: true, title: 'Среднее' }); } catch {}
+
+		const handleResize = () => {
+			if (!containerRef.current || !chart) return;
+			chart.applyOptions({ width: containerRef.current.clientWidth, height: Math.max(containerRef.current.clientHeight || 0, 360) });
+		};
+		window.addEventListener('resize', handleResize);
+		return () => {
+			window.removeEventListener('resize', handleResize);
+			try { chart.remove(); } catch {}
+		};
+	}, [trades, isDark]);
+
+	if (!trades.length) {
+		return <div className="text-gray-500">Нет данных по сделкам</div>;
+	}
+
+	const avgDuration = trades.reduce((s, t) => s + (t.duration ?? 0), 0) / trades.length;
+	const maxDuration = trades.reduce((m, t) => Math.max(m, t.duration ?? 0), 0);
+
+	return (
+		<div className="w-full h-full">
+			<div className="flex flex-wrap gap-4 mb-4 text-sm">
+				<div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+					<span className="text-gray-700 dark:text-gray-200">Средняя длительность: {avgDuration.toFixed(1)} дн.</span>
+				</div>
+				<div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+					<span className="text-gray-700 dark:text-gray-200">Максимальная длительность: {maxDuration.toFixed(0)} дн.</span>
+				</div>
+			</div>
+			<div ref={containerRef} className="w-full h-[360px] min-h-0 overflow-hidden" />
+		</div>
+	);
+}

--- a/src/components/TradesTable.tsx
+++ b/src/components/TradesTable.tsx
@@ -1,0 +1,74 @@
+import type { Trade } from '../types';
+
+interface TradesTableProps {
+	trades: Trade[];
+}
+
+export function TradesTable({ trades }: TradesTableProps) {
+	if (!trades || trades.length === 0) {
+		return (
+			<div className="text-sm text-gray-500">Нет сделок для отображения</div>
+		);
+	}
+
+	const fmtDate = (d: Date) => {
+		try {
+			return new Date(d).toLocaleDateString('ru-RU');
+		} catch {
+			return String(d);
+		}
+	};
+	const fmtTime = (d: Date) => {
+		try {
+			return new Date(d).toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' });
+		} catch {
+			return '';
+		}
+	};
+
+	return (
+		<div className="w-full overflow-auto">
+			<table className="min-w-full text-sm">
+				<thead className="sticky top-0 bg-gray-100 border-b dark:bg-gray-800 dark:border-gray-700">
+					<tr>
+						<th className="text-left px-3 py-2 font-semibold">#</th>
+						<th className="text-left px-3 py-2 font-semibold">Вход</th>
+						<th className="text-left px-3 py-2 font-semibold">Выход</th>
+						<th className="text-right px-3 py-2 font-semibold">Цена входа</th>
+						<th className="text-right px-3 py-2 font-semibold">Цена выхода</th>
+						<th className="text-right px-3 py-2 font-semibold">Кол-во</th>
+						<th className="text-right px-3 py-2 font-semibold">PnL, $</th>
+						<th className="text-right px-3 py-2 font-semibold">PnL, %</th>
+						<th className="text-right px-3 py-2 font-semibold">Дней</th>
+						<th className="text-left px-3 py-2 font-semibold">Причина выхода</th>
+					</tr>
+				</thead>
+				<tbody>
+					{trades.map((t, i) => {
+						const positive = (t.pnl ?? 0) >= 0;
+						return (
+							<tr key={t.id || i} className="border-b last:border-b-0 dark:border-gray-800">
+								<td className="px-3 py-2 text-gray-500">{i + 1}</td>
+								<td className="px-3 py-2 whitespace-nowrap">
+									<div>{fmtDate(t.entryDate)}</div>
+									<div className="text-xs text-gray-500">{fmtTime(t.entryDate)}</div>
+								</td>
+								<td className="px-3 py-2 whitespace-nowrap">
+									<div>{fmtDate(t.exitDate)}</div>
+									<div className="text-xs text-gray-500">{fmtTime(t.exitDate)}</div>
+								</td>
+								<td className="px-3 py-2 text-right font-mono">{t.entryPrice.toFixed(2)}</td>
+								<td className="px-3 py-2 text-right font-mono">{t.exitPrice.toFixed(2)}</td>
+								<td className="px-3 py-2 text-right">{t.quantity.toLocaleString()}</td>
+								<td className={`px-3 py-2 text-right font-mono ${positive ? 'text-emerald-600 dark:text-emerald-300' : 'text-orange-600 dark:text-orange-300'}`}>{(t.pnl ?? 0).toFixed(2)}</td>
+								<td className={`px-3 py-2 text-right font-mono ${positive ? 'text-emerald-600 dark:text-emerald-300' : 'text-orange-600 dark:text-orange-300'}`}>{(t.pnlPercent ?? 0).toFixed(2)}%</td>
+								<td className="px-3 py-2 text-right">{t.duration ?? 0}</td>
+								<td className="px-3 py-2 whitespace-nowrap">{t.exitReason || '-'}</td>
+							</tr>
+						);
+					})}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,6 @@ export { TelegramWatches } from './TelegramWatches';
 export { AppSettings } from './AppSettings';
 export { Footer } from './Footer';
 export { ThemeToggle } from './ThemeToggle';
+export { TradesTable } from './TradesTable';
+export { ProfitFactorChart } from './ProfitFactorChart';
+export { TradeDurationChart } from './TradeDurationChart';


### PR DESCRIPTION
Refactor Results page UI: move mini-chart/prices, add Trades, Profit Factor, and Trade Duration tabs, and make charts full width.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc814376-3527-4cf2-bb9b-16f6e1833b9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc814376-3527-4cf2-bb9b-16f6e1833b9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

