### PR TITLE
Не отображать сигнал закрытия сделки при окончании данных

### DIFF
--- a/src/components/MiniQuoteChart.tsx
+++ b/src/components/MiniQuoteChart.tsx
@@ -101,7 +101,7 @@ export function MiniQuoteChart({ history, today, trades, highIBS, isOpenPosition
       if ((entryTime as number) >= minTime && (entryTime as number) <= maxTime) {
         markers.push({ time: entryTime, position: 'belowBar', color: 'rgba(5,150,105,0.65)', shape: 'arrowUp', text: '' });
       }
-      if ((exitTime as number) >= minTime && (exitTime as number) <= maxTime) {
+      if (t.exitReason !== 'end_of_data' && (exitTime as number) >= minTime && (exitTime as number) <= maxTime) {
         markers.push({ time: exitTime, position: 'aboveBar', color: 'rgba(239,68,68,0.75)', shape: 'arrowDown', text: '' });
       }
     });

--- a/src/components/TradingChart.tsx
+++ b/src/components/TradingChart.tsx
@@ -247,22 +247,27 @@ export function TradingChart({ data, trades, splits = [] }: TradingChartProps) {
       const allMarkers: Array<{ time: UTCTimestamp; position: 'belowBar' | 'aboveBar'; color: string; shape: 'arrowUp'|'arrowDown'|'circle'; text: string } > = [];
       if (trades.length > 0) {
         allMarkers.push(
-          ...trades.flatMap(trade => [
-            {
-              time: Math.floor(trade.entryDate.getTime() / 1000) as UTCTimestamp,
-              position: 'belowBar' as const,
-              color: '#10B981',
-              shape: 'arrowUp' as const,
-              text: '',
-            },
-            {
-              time: Math.floor(trade.exitDate.getTime() / 1000) as UTCTimestamp,
-              position: 'aboveBar' as const,
-              color: '#EF4444',
-              shape: 'arrowDown' as const,
-              text: '',
-            },
-          ])
+          ...trades.flatMap(trade => {
+            const markers: Array<{ time: UTCTimestamp; position: 'belowBar' | 'aboveBar'; color: string; shape: 'arrowUp'|'arrowDown'|'circle'; text: string }> = [
+              {
+                time: Math.floor(trade.entryDate.getTime() / 1000) as UTCTimestamp,
+                position: 'belowBar' as const,
+                color: '#10B981',
+                shape: 'arrowUp' as const,
+                text: '',
+              },
+            ];
+            if (trade.exitReason !== 'end_of_data') {
+              markers.push({
+                time: Math.floor(trade.exitDate.getTime() / 1000) as UTCTimestamp,
+                position: 'aboveBar' as const,
+                color: '#EF4444',
+                shape: 'arrowDown' as const,
+                text: '',
+              });
+            }
+            return markers;
+          })
         );
       }
       if (splits.length > 0) {


### PR DESCRIPTION
Hide trade exit markers on charts when the exit reason is 'end_of_data'.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef5aa01f-0f41-461b-96aa-fce0f5e476ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef5aa01f-0f41-461b-96aa-fce0f5e476ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

