### PR TITLE
Investigate 11 minute test submission failure

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -678,7 +678,7 @@ async function runTelegramAggregation(minutesOverride = null, options = {}) {
   try {
     if (telegramWatches.size === 0) return { sent: false };
     const nowEt = getETParts(new Date());
-    if (!isTradingDayET(nowEt)) return { sent: false };
+    if (!isTradingDayET(nowEt) && !(options && options.test)) return { sent: false };
     const minutesUntilClose = minutesOverride != null ? minutesOverride : ((16 * 60) - (nowEt.hh * 60 + nowEt.mm));
     if (minutesUntilClose !== 11 && minutesUntilClose !== 2) return { sent: false };
 


### PR DESCRIPTION
Allow test simulation to run on non-trading days to enable testing on weekends.

The `runTelegramAggregation` function, which handles the "Test: 11 min" simulation, was previously blocked on non-trading days (weekends/holidays). This change specifically bypasses the trading day check when the `test` option is present, allowing the test to run on any day without affecting the regular scheduler.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd0b9ce8-969d-491e-ae58-a7ac5f5b92c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd0b9ce8-969d-491e-ae58-a7ac5f5b92c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

