### PR TITLE
Удалить tradingibs.site из кода

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,9 @@ trading_strategies/
 - `/api/*` → `server:3001`
 - `/` → `frontend:80`
 
-`caddy/Caddyfile` (пример для домена `tradingibs.site`):
+`caddy/Caddyfile` (пример для домена `example.com`):
 ```
-tradingibs.site {
+example.com {
   encode gzip
   log {
     output file /var/log/caddy/access.log
@@ -231,8 +231,8 @@ docker compose down
 docker compose up -d --build
 ```
 Проверка:
-- `https://tradingibs.site/` → SPA
-- `https://tradingibs.site/api/status` → 200 ok
+- `https://example.com/` → SPA
+- `https://example.com/api/status` → 200 ok
 
 TLS‑сертификаты выпускаются автоматически (Let’s Encrypt) — дополнительные ключи не нужны.
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,4 +1,4 @@
-tradingibs.site {
+example.com {
   encode gzip
   log {
     output file /var/log/caddy/access.log


### PR DESCRIPTION
Replace `tradingibs.site` with `example.com` to generalize the configuration examples.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f108529-5375-4ad4-b0e8-d7e9d6333055">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f108529-5375-4ad4-b0e8-d7e9d6333055">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

