### PR TITLE
Adjust IBS and volume chart height and colors

### DIFF
--- a/src/components/TradingChart.tsx
+++ b/src/components/TradingChart.tsx
@@ -72,7 +72,7 @@ export function TradingChart({ data, trades, splits = [] }: TradingChartProps) {
         layout: { background: { color: bg }, textColor: text },
         grid: { vertLines: { color: grid }, horzLines: { color: grid } },
         crosshair: { mode: 1 },
-        rightPriceScale: { borderColor: border, scaleMargins: { top: 0.05, bottom: 0.25 } },
+        rightPriceScale: { borderColor: border, scaleMargins: { top: 0.05, bottom: 0.20 } },
         timeScale: { borderColor: border, timeVisible: true, secondsVisible: false, rightOffset: 8 },
       });
 
@@ -139,8 +139,8 @@ export function TradingChart({ data, trades, splits = [] }: TradingChartProps) {
         const range = Math.max(1e-9, bar.high - bar.low);
         const ibs = (bar.close - bar.low) / range; // 0..1
         const color = ibs <= 0.10
-          ? (isDark ? 'rgba(16,185,129,0.9)' : 'rgba(16,185,129,0.9)')
-          : (ibs >= 0.75 ? (isDark ? 'rgba(239,68,68,0.9)' : 'rgba(239,68,68,0.9)') : (isDark ? 'rgba(156,163,175,0.9)' : 'rgba(107,114,128,0.9)'));
+          ? (isDark ? 'rgba(16,185,129,1)' : 'rgba(16,185,129,1)')
+          : (ibs >= 0.75 ? (isDark ? 'rgba(239,68,68,0.3)' : 'rgba(239,68,68,0.35)') : (isDark ? 'rgba(156,163,175,0.9)' : 'rgba(107,114,128,0.9)'));
         return { time: Math.floor(bar.date.getTime() / 1000) as UTCTimestamp, value: ibs, color };
       });
       ibsHist.setData(ibsData);


### PR DESCRIPTION
Limit indicator panel height to 20% and adjust IBS bar colors for improved visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-53badd38-dfb0-485d-ba8a-95f58bc3143b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53badd38-dfb0-485d-ba8a-95f58bc3143b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

