### PR TITLE
Добавить симулятор маржи на страницу аналитики

### DIFF
--- a/src/components/EquityChart.tsx
+++ b/src/components/EquityChart.tsx
@@ -4,9 +4,10 @@ import type { EquityPoint } from '../types';
 
 interface EquityChartProps {
   equity: EquityPoint[];
+  hideHeader?: boolean;
 }
 
-export function EquityChart({ equity }: EquityChartProps) {
+export function EquityChart({ equity, hideHeader }: EquityChartProps) {
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const [isDark, setIsDark] = useState<boolean>(() => typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false);
@@ -156,16 +157,18 @@ export function EquityChart({ equity }: EquityChartProps) {
 
   return (
     <div className="w-full h-full">
-      <div className="flex flex-wrap gap-4 mb-4 text-sm">
-        <div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
-          <span className="text-gray-700 dark:text-gray-200">Итоговый портфель: {finalValue.toFixed(2)}</span>
-        </div>
-        {(startDate && endDate) && (
+      {!hideHeader && (
+        <div className="flex flex-wrap gap-4 mb-4 text-sm">
           <div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
-            <span className="text-gray-700 dark:text-gray-200">Период: {startDate} — {endDate}</span>
+            <span className="text-gray-700 dark:text-gray-200">Итоговый портфель: {finalValue.toFixed(2)}</span>
           </div>
-        )}
-      </div>
+          {(startDate && endDate) && (
+            <div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+              <span className="text-gray-700 dark:text-gray-200">Период: {startDate} — {endDate}</span>
+            </div>
+          )}
+        </div>
+      )}
       <div ref={chartContainerRef} className="w-full h-[600px] min-h-0 overflow-hidden" />
     </div>
   );

--- a/src/components/MarginSimulator.tsx
+++ b/src/components/MarginSimulator.tsx
@@ -1,0 +1,127 @@
+import { useMemo, useState } from 'react';
+import type { EquityPoint } from '../types';
+import { EquityChart } from './EquityChart';
+
+interface MarginSimulatorProps {
+  equity: EquityPoint[];
+}
+
+interface SimulationResult {
+  equity: EquityPoint[];
+  maxDrawdown: number;
+  finalValue: number;
+  marginCall: boolean;
+  marginCallDate?: Date;
+}
+
+function simulateLeverage(equity: EquityPoint[], leverage: number): SimulationResult {
+  if (!equity || equity.length === 0 || leverage <= 0) {
+    return { equity: [], maxDrawdown: 0, finalValue: 0, marginCall: false };
+  }
+
+  const result: EquityPoint[] = [];
+  let prevValue = equity[0].value;
+  let currentValue = prevValue;
+  let peakValue = currentValue;
+  let maxDD = 0;
+  result.push({ date: equity[0].date, value: currentValue, drawdown: 0 });
+
+  let marginCall = false;
+  let marginCallDate: Date | undefined = undefined;
+
+  for (let i = 1; i < equity.length; i++) {
+    const basePrev = equity[i - 1].value;
+    const baseCurr = equity[i].value;
+    if (basePrev <= 0) continue;
+    const baseReturn = (baseCurr - basePrev) / basePrev;
+    const leveragedReturn = baseReturn * leverage;
+    currentValue = currentValue * (1 + leveragedReturn);
+
+    if (currentValue <= 0) {
+      currentValue = 0;
+      marginCall = true;
+      marginCallDate = equity[i].date;
+      maxDD = 100;
+      result.push({ date: equity[i].date, value: currentValue, drawdown: 100 });
+      break;
+    }
+
+    if (currentValue > peakValue) peakValue = currentValue;
+    const dd = peakValue > 0 ? ((peakValue - currentValue) / peakValue) * 100 : 0;
+    if (dd > maxDD) maxDD = dd;
+    result.push({ date: equity[i].date, value: currentValue, drawdown: dd });
+  }
+
+  const finalValue = result[result.length - 1]?.value ?? currentValue;
+  return { equity: result, maxDrawdown: maxDD, finalValue, marginCall, marginCallDate };
+}
+
+export function MarginSimulator({ equity }: MarginSimulatorProps) {
+  const [marginPctInput, setMarginPctInput] = useState<string>('200');
+  const [appliedLeverage, setAppliedLeverage] = useState<number>(2);
+
+  const { simEquity, simMaxDD, simFinal, marginCall, marginDate } = useMemo(() => {
+    const leverage = appliedLeverage;
+    const sim = simulateLeverage(equity, leverage);
+    return {
+      simEquity: sim.equity,
+      simMaxDD: sim.maxDrawdown,
+      simFinal: sim.finalValue,
+      marginCall: sim.marginCall,
+      marginDate: sim.marginCallDate,
+    };
+  }, [equity, appliedLeverage]);
+
+  const onApply = () => {
+    const pct = Number(marginPctInput);
+    if (!isFinite(pct) || pct <= 0) return;
+    setAppliedLeverage(pct / 100);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col">
+          <label className="text-xs text-gray-600 dark:text-gray-300">Маржинальность, %</label>
+          <input
+            type="number"
+            inputMode="decimal"
+            min={1}
+            step={1}
+            value={marginPctInput}
+            onChange={(e) => setMarginPctInput(e.target.value)}
+            className="px-3 py-2 border rounded-md w-40 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+            placeholder="например, 200"
+          />
+        </div>
+        <button
+          onClick={onApply}
+          className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+        >
+          Посчитать
+        </button>
+        <div className="text-xs text-gray-500 dark:text-gray-300">
+          Текущее плечо: ×{appliedLeverage.toFixed(2)}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-3 text-sm">
+        <div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+          Итоговый депозит: {simFinal.toFixed(2)}
+        </div>
+        <div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+          Макс. просадка: {simMaxDD.toFixed(2)}%
+        </div>
+        {marginCall && (
+          <div className="px-3 py-2 rounded border border-red-300 bg-red-50 text-red-800 dark:bg-red-900/30 dark:border-red-800 dark:text-red-200">
+            Margin call: баланс ушёл в ноль{marginDate ? ` (${new Date(marginDate).toLocaleDateString('ru-RU')})` : ''}
+          </div>
+        )}
+      </div>
+
+      <div className="h-[600px]">
+        <EquityChart equity={simEquity} hideHeader />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -12,6 +12,7 @@ import { TradesTable } from './TradesTable';
 import { ProfitFactorChart } from './ProfitFactorChart';
 import { TradeDurationChart } from './TradeDurationChart';
 import { OpenDayDrawdownChart } from './OpenDayDrawdownChart';
+import { MarginSimulator } from './MarginSimulator';
 
 export function Results() {
   const backtestResults = useAppStore(s => s.backtestResults);
@@ -38,7 +39,7 @@ export function Results() {
   const [watching, setWatching] = useState(false);
   const [watchBusy, setWatchBusy] = useState(false);
   
-  type ChartTab = 'price' | 'equity' | 'drawdown' | 'trades' | 'profit' | 'duration' | 'openDayDrawdown';
+  type ChartTab = 'price' | 'equity' | 'drawdown' | 'trades' | 'profit' | 'duration' | 'openDayDrawdown' | 'margin';
   const [activeChart, setActiveChart] = useState<ChartTab>('price');
   
   // Проверка дублей дат в marketData (ключ YYYY-MM-DD)
@@ -560,6 +561,7 @@ export function Results() {
               <button className={`${activeChart === 'profit' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('profit')}>Profit factor</button>
               <button className={`${activeChart === 'duration' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('duration')}>Длительность</button>
               <button className={`${activeChart === 'openDayDrawdown' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('openDayDrawdown')}>Просадка в день открытия</button>
+              <button className={`${activeChart === 'margin' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('margin')}>Маржа</button>
             </div>
 
             {activeChart === 'price' && (
@@ -584,6 +586,9 @@ export function Results() {
             )}
             {activeChart === 'openDayDrawdown' && (
               <OpenDayDrawdownChart trades={trades} data={marketData} />
+            )}
+            {activeChart === 'margin' && (
+              <MarginSimulator equity={equity} />
             )}
           </section>
         </div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,3 +15,4 @@ export { TradesTable } from './TradesTable';
 export { ProfitFactorChart } from './ProfitFactorChart';
 export { TradeDurationChart } from './TradeDurationChart';
 export { OpenDayDrawdownChart } from './OpenDayDrawdownChart';
+export { MarginSimulator } from './MarginSimulator';


### PR DESCRIPTION
Add a margin simulator to the results page, allowing users to calculate and visualize leveraged equity, final deposit, max drawdown, and detect margin calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3a8b0f7-9142-4858-a3dc-fa324bc7a506">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3a8b0f7-9142-4858-a3dc-fa324bc7a506">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

