### PR TITLE
Migrate data and settings to docker volumes and secrets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+  # Production (default) — data in named volumes, secrets via env_file or Docker secrets
   server:
     build:
       context: .
@@ -9,25 +10,15 @@ services:
       - ./server/.env
     environment:
       - PORT=3001
-      - ADMIN_USERNAME=${ADMIN_USERNAME:-admin@example.com}
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - FRONTEND_ORIGIN=${FRONTEND_ORIGIN:-http://localhost}
       - BUILD_ID=${BUILD_ID:-dev}
-      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
-      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
-      - ALPHA_VANTAGE_API_KEY=${ALPHA_VANTAGE_API_KEY}
-      - FINNHUB_API_KEY=${FINNHUB_API_KEY}
-      - TWELVE_DATA_API_KEY=${TWELVE_DATA_API_KEY}
-      - POLYGON_API_KEY=${POLYGON_API_KEY}
-      # Можно переопределить пути логов (по умолчанию они в datasets/)
-      # - MONITOR_LOG_PATH=/app/server/datasets/monitoring.log
-      # - LOGIN_LOG_PATH=/app/server/datasets/login-attempts.log
+      - DATASETS_DIR=/data/datasets
+      - SETTINGS_FILE=/data/state/settings.json
+      - WATCHES_FILE=/data/state/telegram-watches.json
+      - SPLITS_FILE=/data/state/splits.json
     volumes:
-      - ./server/datasets:/app/server/datasets
-      - ./server/settings.json:/app/server/settings.json
-      - ./server/telegram-watches.json:/app/server/telegram-watches.json
-      - ./server/splits.json:/app/server/splits.json
-      - ./server/.env:/app/.env:ro
+      - stonks_datasets:/data/datasets
+      - stonks_state:/data/state
     ports:
       - "3001:3001"
     restart: unless-stopped
@@ -69,5 +60,64 @@ services:
       - server
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+
+  # Development profile — convenient bind mounts to repo files
+  server-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: docker/server.Dockerfile
+      args:
+        BUILD_ID: "${BUILD_ID:-dev}"
+    env_file:
+      - ./server/.env
+    environment:
+      - PORT=3001
+      - FRONTEND_ORIGIN=${FRONTEND_ORIGIN:-http://localhost:5173}
+      - BUILD_ID=${BUILD_ID:-dev}
+      - DATASETS_DIR=/data/datasets
+      - SETTINGS_FILE=/data/state/settings.json
+      - WATCHES_FILE=/data/state/telegram-watches.json
+      - SPLITS_FILE=/data/state/splits.json
+    volumes:
+      - ./server/datasets:/data/datasets
+      - ./server/settings.json:/data/state/settings.json
+      - ./server/telegram-watches.json:/data/state/telegram-watches.json
+      - ./server/splits.json:/data/state/splits.json
+    ports:
+      - "3001:3001"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3001/api/status').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  frontend-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: docker/frontend.Dockerfile
+      args:
+        PUBLIC_BASE_PATH: "/"
+        VITE_API_BASE: "/api"
+        VITE_BUILD_ID: "${BUILD_ID:-dev}"
+    depends_on:
+      - server-dev
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/api/status" ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    environment:
+      - PUBLIC_BASE_PATH=/
+      - VITE_API_BASE=/api
+
+volumes:
+  stonks_datasets:
+  stonks_state:
 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+# Defaults for data locations (can be overridden by env)
+: "${DATASETS_DIR:=/data/datasets}"
+: "${SETTINGS_FILE:=/data/state/settings.json}"
+: "${WATCHES_FILE:=/data/state/telegram-watches.json}"
+: "${SPLITS_FILE:=/data/state/splits.json}"
+
+legacy_dir="/app/server"
+
+mkdir -p "$DATASETS_DIR" "$(dirname "$SETTINGS_FILE")" "$(dirname "$WATCHES_FILE")" "$(dirname "$SPLITS_FILE")"
+
+# One-time migration: if the target datasets dir is empty, seed from legacy path
+if [ -z "$(ls -A "$DATASETS_DIR" 2>/dev/null || true)" ]; then
+  if [ -d "$legacy_dir/datasets" ]; then
+    echo "Seeding datasets into $DATASETS_DIR from $legacy_dir/datasets"
+    cp -rT "$legacy_dir/datasets" "$DATASETS_DIR" || true
+  fi
+fi
+
+# Seed config/state files if not present in the volume
+if [ ! -f "$SETTINGS_FILE" ]; then
+  if [ -f "$legacy_dir/settings.json" ]; then
+    cp "$legacy_dir/settings.json" "$SETTINGS_FILE" || echo "{}" > "$SETTINGS_FILE"
+  else
+    echo "{}" > "$SETTINGS_FILE"
+  fi
+fi
+
+if [ ! -f "$WATCHES_FILE" ]; then
+  if [ -f "$legacy_dir/telegram-watches.json" ]; then
+    cp "$legacy_dir/telegram-watches.json" "$WATCHES_FILE" || echo "[]" > "$WATCHES_FILE"
+  else
+    echo "[]" > "$WATCHES_FILE"
+  fi
+fi
+
+if [ ! -f "$SPLITS_FILE" ]; then
+  if [ -f "$legacy_dir/splits.json" ]; then
+    cp "$legacy_dir/splits.json" "$SPLITS_FILE" || echo "{}" > "$SPLITS_FILE"
+  else
+    echo "{}" > "$SPLITS_FILE"
+  fi
+fi
+
+# Load Docker secrets if present and not already set via env
+load_secret() {
+  name="$1"
+  file="/run/secrets/$1"
+  eval current_val="\${$1:-}"
+  if [ -z "$current_val" ] && [ -f "$file" ]; then
+    export "$name"="$(cat "$file")"
+  fi
+}
+
+for s in \
+  ADMIN_USERNAME \
+  ADMIN_PASSWORD \
+  TELEGRAM_BOT_TOKEN \
+  TELEGRAM_CHAT_ID \
+  ALPHA_VANTAGE_API_KEY \
+  FINNHUB_API_KEY \
+  TWELVE_DATA_API_KEY \
+  POLYGON_API_KEY
+do
+  load_secret "$s"
+done
+
+exec "$@"
+

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -21,14 +21,21 @@ RUN set -e; cd server; npm config set registry "${NPM_CONFIG_REGISTRY}"; for i i
     done
 
 COPY server ./server
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 # Inject build id into runtime image (available to server via process.env.BUILD_ID)
 ARG BUILD_ID=dev
 ENV BUILD_ID=$BUILD_ID
 # Ensure dotenv loads if mounted .env present at /app/.env
 ENV NODE_ENV=production
 
-ENV PORT=3001
+ENV PORT=3001 \
+    DATASETS_DIR=/data/datasets \
+    SETTINGS_FILE=/data/state/settings.json \
+    WATCHES_FILE=/data/state/telegram-watches.json \
+    SPLITS_FILE=/data/state/splits.json
 EXPOSE 3001
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["node", "server/server.js"]
 
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,24 @@
+PORT=3001
+# Frontend origin for CORS in dev
+FRONTEND_ORIGIN=http://localhost:5173
+
+# Admin auth (leave ADMIN_PASSWORD empty to disable auth in dev)
+ADMIN_USERNAME=admin@example.com
+ADMIN_PASSWORD=
+
+# Optional integrations
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+ALPHA_VANTAGE_API_KEY=
+FINNHUB_API_KEY=
+TWELVE_DATA_API_KEY=
+POLYGON_API_KEY=
+
+# Data locations (overridable; defaults match container entrypoint)
+DATASETS_DIR=/data/datasets
+SETTINGS_FILE=/data/state/settings.json
+WATCHES_FILE=/data/state/telegram-watches.json
+SPLITS_FILE=/data/state/splits.json
 # Trading Backtester API Configuration
 
 # Server Configuration


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Migrate persistent data to Docker named volumes and secrets, and introduce `docker-compose` profiles for robust updates and environment management.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change prevents data loss or corruption during Git updates by moving persistent data (datasets, settings, watches, splits) to Docker named volumes, which are managed independently of the repository. It also standardizes secret management via `env_file` or Docker secrets and provides distinct `prod` (volumes, secrets) and `dev` (bind mounts) `docker-compose` profiles, along with a one-time migration script for existing data.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b1d60ce-2832-472c-9371-44239c9024b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b1d60ce-2832-472c-9371-44239c9024b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

