### PR TITLE
Fix caddy ssl certificate persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,9 @@ services:
       - server
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    restart: unless-stopped
 
   # Development profile — convenient bind mounts to repo files
   server-dev:
@@ -119,5 +122,9 @@ services:
 volumes:
   stonks_datasets:
   stonks_state:
+  caddy_data:
+    driver: local
+  caddy_config:
+    driver: local
 
 


### PR DESCRIPTION
Add persistent volumes for Caddy to prevent loss of SSL certificates and ACME accounts on container restarts.

Previously, Caddy's certificates and ACME accounts were lost on every container restart due to a lack of persistent storage, leading to repeated requests to Let's Encrypt and hitting their rate limits. This change ensures certificates and account data are preserved across restarts.

---
<a href="https://cursor.com/background-agent?bcId=bc-4bb343d9-79cd-4726-b8a3-18a71650381d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4bb343d9-79cd-4726-b8a3-18a71650381d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

