### PR TITLE
Update market closing data after market close

### DIFF
--- a/src/components/SplitPage.tsx
+++ b/src/components/SplitPage.tsx
@@ -104,7 +104,8 @@ export function SplitPage() {
 						dataPoints: dataset.dataPoints as number,
 						dateRange: dataset.dateRange as { from: string; to: string },
 						adjustedForSplits: dataset.adjustedForSplits === true,
-				})) as DatasetMeta[];
+					};
+				}) as DatasetMeta[];
 				setDatasets(normalized);
 			} catch {
 				// Ignore dataset refresh errors

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -395,6 +395,12 @@ export class DatasetAPI {
     return response.json();
   }
 
+  static async getTradingCalendar(): Promise<any> {
+    const response = await fetchWithCreds(`${API_BASE_URL}/trading-calendar`);
+    if (!response.ok) throw new Error(`Failed to load trading calendar: ${response.status} ${response.statusText}`);
+    return response.json();
+  }
+
   static async saveAppSettings(settings: { watchThresholdPct: number; resultsQuoteProvider: 'alpha_vantage'|'finnhub'; enhancerProvider: 'alpha_vantage'|'finnhub'; resultsRefreshProvider?: 'alpha_vantage'|'finnhub'; indicatorPanePercent?: number }): Promise<void> {
     const response = await fetchWithCreds(`${API_BASE_URL}/settings`, {
       method: 'PUT',


### PR DESCRIPTION
Enable immediate display of the "Обновить данные" button after market close, including early-close days, for instant data refresh.

Previously, the "Обновить данные" button on the results page had a 30-minute delay after the market officially closed (16:00 ET) before it became active. This PR removes that delay, making the button available immediately at market close. Additionally, it integrates a trading calendar to detect early-close days, ensuring the button is available at 13:00 ET on those specific days. The server-side refresh endpoint was also updated to correctly use the configured data provider (Finnhub or Alpha Vantage). A minor build-breaking syntax error in `SplitPage.tsx` was also fixed.

---
<a href="https://cursor.com/background-agent?bcId=bc-51c4f3fd-05ad-43b4-b3c6-a6336754d2c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51c4f3fd-05ad-43b4-b3c6-a6336754d2c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

