### PR TITLE
Добавить вкладку "Без stop loss" для симулятора доходности

### DIFF
--- a/src/components/NoStopLossSimulator.tsx
+++ b/src/components/NoStopLossSimulator.tsx
@@ -1,0 +1,179 @@
+import React, { useMemo, useState } from 'react';
+import type { EquityPoint, OHLCData, Strategy } from '../types';
+import { IndicatorEngine } from '../lib/indicators';
+import { EquityChart } from './EquityChart';
+
+interface NoStopLossSimulatorProps {
+  data: OHLCData[];
+  strategy: Strategy | null | undefined;
+}
+
+interface SimulationResult {
+  equity: EquityPoint[];
+  maxDrawdown: number;
+  finalValue: number;
+}
+
+function simulateNoStopLoss(
+  data: OHLCData[],
+  lowIBS: number,
+  initialCapital: number,
+  capitalUsage: number
+): SimulationResult {
+  if (!Array.isArray(data) || data.length === 0) {
+    return { equity: [], maxDrawdown: 0, finalValue: 0 };
+  }
+
+  const ibsValues = IndicatorEngine.calculateIBS(data);
+
+  let currentCapital = initialCapital;
+  let peakValue = currentCapital;
+  let maxDrawdown = 0;
+  const equity: EquityPoint[] = [];
+
+  let position: { entryIndex: number; entryDate: Date; entryPrice: number; quantity: number } | null = null;
+
+  for (let i = 0; i < data.length; i++) {
+    const bar = data[i];
+    const ibs = ibsValues[i];
+
+    // Entries: when IBS < lowIBS, execute at next day's open
+    if (!position && typeof ibs === 'number' && !isNaN(ibs) && ibs < lowIBS && i < data.length - 1) {
+      const nextBar = data[i + 1];
+      const investAmount = (currentCapital * (capitalUsage || 100)) / 100;
+      const quantity = Math.floor(investAmount / nextBar.open);
+      if (quantity > 0) {
+        const cost = quantity * nextBar.open;
+        currentCapital -= cost;
+        position = {
+          entryIndex: i + 1,
+          entryDate: nextBar.date,
+          entryPrice: nextBar.open,
+          quantity,
+        };
+      }
+    }
+
+    // Exits: only at break-even (bar.high >= entryPrice), and only after the entry day
+    if (position && i > position.entryIndex) {
+      if (bar.high >= position.entryPrice) {
+        // Exit exactly at entryPrice (break-even)
+        const proceeds = position.quantity * position.entryPrice;
+        currentCapital += proceeds;
+        position = null;
+      }
+    }
+
+    // Update equity curve (include position value at close)
+    let totalValue = currentCapital;
+    if (position && i >= position.entryIndex) {
+      totalValue += position.quantity * bar.close;
+    }
+    if (totalValue > peakValue) peakValue = totalValue;
+    const dd = peakValue > 0 ? ((peakValue - totalValue) / peakValue) * 100 : 0;
+    if (dd > maxDrawdown) maxDrawdown = dd;
+
+    equity.push({ date: bar.date, value: totalValue, drawdown: dd });
+  }
+
+  const finalValue = equity[equity.length - 1]?.value ?? currentCapital;
+  return { equity, maxDrawdown, finalValue };
+}
+
+function simulateLeverage(equity: EquityPoint[], leverage: number): { equity: EquityPoint[]; maxDrawdown: number; finalValue: number } {
+  if (!equity || equity.length === 0 || leverage <= 0) {
+    return { equity: [], maxDrawdown: 0, finalValue: 0 };
+  }
+
+  const result: EquityPoint[] = [];
+  let currentValue = equity[0].value;
+  let peakValue = currentValue;
+  let maxDD = 0;
+  result.push({ date: equity[0].date, value: currentValue, drawdown: 0 });
+
+  for (let i = 1; i < equity.length; i++) {
+    const basePrev = equity[i - 1].value;
+    const baseCurr = equity[i].value;
+    if (basePrev <= 0) continue;
+    const baseReturn = (baseCurr - basePrev) / basePrev;
+    const leveragedReturn = baseReturn * leverage;
+    currentValue = currentValue * (1 + leveragedReturn);
+    if (currentValue < 0) currentValue = 0;
+
+    if (currentValue > peakValue) peakValue = currentValue;
+    const dd = peakValue > 0 ? ((peakValue - currentValue) / peakValue) * 100 : 0;
+    if (dd > maxDD) maxDD = dd;
+    result.push({ date: equity[i].date, value: currentValue, drawdown: dd });
+  }
+
+  return { equity: result, maxDrawdown: maxDD, finalValue: result[result.length - 1]?.value ?? currentValue };
+}
+
+export function NoStopLossSimulator({ data, strategy }: NoStopLossSimulatorProps) {
+  const lowIBS = Number(strategy?.parameters?.lowIBS ?? 0.1);
+  const initialCapital = Number(strategy?.riskManagement?.initialCapital ?? 10000);
+  const capitalUsage = Number(strategy?.riskManagement?.capitalUsage ?? 100);
+
+  const base = useMemo(() => simulateNoStopLoss(data, lowIBS, initialCapital, capitalUsage), [data, lowIBS, initialCapital, capitalUsage]);
+
+  const [marginPctInput, setMarginPctInput] = useState<string>('100');
+  const [appliedLeverage, setAppliedLeverage] = useState<number>(1);
+
+  const { simEquity, simMaxDD, simFinal } = useMemo(() => {
+    const sim = simulateLeverage(base.equity, appliedLeverage);
+    return {
+      simEquity: sim.equity,
+      simMaxDD: sim.maxDrawdown,
+      simFinal: sim.finalValue,
+    };
+  }, [base.equity, appliedLeverage]);
+
+  const onApply = () => {
+    const pct = Number(marginPctInput);
+    if (!isFinite(pct) || pct <= 0) return;
+    setAppliedLeverage(pct / 100);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col">
+          <label className="text-xs text-gray-600 dark:text-gray-300">Маржинальность, %</label>
+          <input
+            type="number"
+            inputMode="decimal"
+            min={1}
+            step={1}
+            value={marginPctInput}
+            onChange={(e) => setMarginPctInput(e.target.value)}
+            className="px-3 py-2 border rounded-md w-40 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+            placeholder="например, 100"
+          />
+        </div>
+        <button
+          onClick={onApply}
+          className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+        >
+          Посчитать
+        </button>
+        <div className="text-xs text-gray-500 dark:text-gray-300">
+          Текущее плечо: ×{appliedLeverage.toFixed(2)}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-3 text-sm">
+        <div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+          Итоговый депозит: {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(simFinal)}
+        </div>
+        <div className="bg-gray-50 px-3 py-2 rounded border dark:bg-gray-800 dark:border-gray-700">
+          Макс. просадка: {simMaxDD.toFixed(2)}%
+        </div>
+      </div>
+
+      <div className="h-[600px]">
+        <EquityChart equity={simEquity} hideHeader />
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -13,6 +13,7 @@ import { ProfitFactorChart } from './ProfitFactorChart';
 import { TradeDurationChart } from './TradeDurationChart';
 import { OpenDayDrawdownChart } from './OpenDayDrawdownChart';
 import { MarginSimulator } from './MarginSimulator';
+import { NoStopLossSimulator } from './NoStopLossSimulator';
 
 export function Results() {
   const backtestResults = useAppStore(s => s.backtestResults);
@@ -39,7 +40,7 @@ export function Results() {
   const [watching, setWatching] = useState(false);
   const [watchBusy, setWatchBusy] = useState(false);
   
-  type ChartTab = 'price' | 'equity' | 'drawdown' | 'trades' | 'profit' | 'duration' | 'openDayDrawdown' | 'margin' | 'splits';
+  type ChartTab = 'price' | 'equity' | 'drawdown' | 'trades' | 'profit' | 'duration' | 'openDayDrawdown' | 'margin' | 'noStopLoss' | 'splits';
   const [activeChart, setActiveChart] = useState<ChartTab>('price');
   
   // Проверка дублей дат в marketData (ключ YYYY-MM-DD)
@@ -563,6 +564,7 @@ export function Results() {
               <button className={`${activeChart === 'duration' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('duration')}>Длительность</button>
               <button className={`${activeChart === 'openDayDrawdown' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('openDayDrawdown')}>Стартовая просадка</button>
               <button className={`${activeChart === 'margin' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('margin')}>Маржа</button>
+              <button className={`${activeChart === 'noStopLoss' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('noStopLoss')}>Без stop loss</button>
               <button className={`${activeChart === 'splits' ? 'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-950/30 dark:border-blue-900/40 dark:text-blue-200' : 'bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300'} px-3 py-1.5 rounded border`} onClick={() => setActiveChart('splits')}>Сплиты</button>
               </div>
             </div>
@@ -592,6 +594,9 @@ export function Results() {
             )}
             {activeChart === 'margin' && (
               <MarginSimulator equity={equity} />
+            )}
+            {activeChart === 'noStopLoss' && (
+              <NoStopLossSimulator data={marketData} strategy={currentStrategy} />
             )}
             {activeChart === 'splits' && (
               <div className="space-y-4">

--- a/src/components/SplitPage.tsx
+++ b/src/components/SplitPage.tsx
@@ -104,7 +104,8 @@ export function SplitPage() {
 						dataPoints: dataset.dataPoints as number,
 						dateRange: dataset.dateRange as { from: string; to: string },
 						adjustedForSplits: dataset.adjustedForSplits === true,
-				})) as DatasetMeta[];
+					};
+				}) as DatasetMeta[];
 				setDatasets(normalized);
 			} catch {
 				// Ignore dataset refresh errors


### PR DESCRIPTION
Adds a 'Без stop loss' tab to the deals analytics section with a simulator for break-even exit strategy profitability and optional leverage, and includes a minor syntax fix in `SplitPage.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-82b152a3-2d79-449a-a437-794a190fb443">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82b152a3-2d79-449a-a437-794a190fb443">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

