### PR TITLE
Fix automatic redirection to results page

### DIFF
--- a/src/components/DatasetLibrary.tsx
+++ b/src/components/DatasetLibrary.tsx
@@ -5,8 +5,10 @@ import { createStrategyFromTemplate, STRATEGY_TEMPLATES } from '../lib/strategy'
 import { DatasetAPI, API_BASE_URL } from '../lib/api';
 import type { SavedDataset } from '../types';
 import { ConfirmModal } from './ConfirmModal';
+import { useNavigate } from 'react-router-dom';
 
 export function DatasetLibrary({ onAfterLoad }: { onAfterLoad?: () => void } = {}) {
+  const navigate = useNavigate();
   const savedDatasets = useAppStore(s => s.savedDatasets);
   const currentDataset = useAppStore(s => s.currentDataset);
   const currentStrategy = useAppStore(s => s.currentStrategy);
@@ -96,8 +98,8 @@ export function DatasetLibrary({ onAfterLoad }: { onAfterLoad?: () => void } = {
       }
       // снимаем лоадер сразу
       setLoadingId(null);
-      // мгновенно переходим на «Результаты» и фиксируем hash
-      try { window.history.pushState({}, '', '/results'); } catch { /* ignore */ }
+      // мгновенно переходим на «Результаты» через роутер
+      try { navigate('/results'); } catch { /* ignore */ }
       if (onAfterLoad) onAfterLoad();
       // запускаем бэктест в фоне, не блокируя UI
       try { runBacktest?.(); } catch (e) { console.warn('Failed to start backtest', e); }


### PR DESCRIPTION
Use React Router's `navigate` to ensure consistent redirection to the "Результаты" page after every ticker selection.

The previous implementation used `window.history.pushState`, which does not reliably trigger React Router updates, causing the automatic redirect to fail on subsequent ticker selections.

---
<a href="https://cursor.com/background-agent?bcId=bc-97aca06d-5b62-452d-bb19-71a0b8e4ad3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97aca06d-5b62-452d-bb19-71a0b8e4ad3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

