### PR TITLE
Hide ema lines with insufficient data

### DIFF
--- a/src/components/TradingChart.tsx
+++ b/src/components/TradingChart.tsx
@@ -173,10 +173,16 @@ export function TradingChart({ data, trades, splits = [] }: TradingChartProps) {
         title: 'EMA 20',
         visible: false,
       });
-      const ema20Data = data.map((bar, index) => ({
-        time: Math.floor(bar.date.getTime() / 1000) as UTCTimestamp,
-        value: ema20Values[index] || bar.close,
-      })).filter((point: { time: UTCTimestamp; value: number }) => point.value !== undefined);
+      const ema20Data = data
+        .map((bar, index) => {
+          const v = ema20Values[index];
+          if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+          return {
+            time: Math.floor(bar.date.getTime() / 1000) as UTCTimestamp,
+            value: v,
+          };
+        })
+        .filter((point: { time: UTCTimestamp; value: number } | null): point is { time: UTCTimestamp; value: number } => point !== null);
       ema20Series.setData(ema20Data);
       ema20SeriesRef.current = ema20Series;
 
@@ -187,10 +193,16 @@ export function TradingChart({ data, trades, splits = [] }: TradingChartProps) {
         title: 'EMA 200',
         visible: false,
       });
-      const ema200Data = data.map((bar, index) => ({
-        time: Math.floor(bar.date.getTime() / 1000) as UTCTimestamp,
-        value: ema200Values[index] || bar.close,
-      })).filter((point: { time: UTCTimestamp; value: number }) => point.value !== undefined);
+      const ema200Data = data
+        .map((bar, index) => {
+          const v = ema200Values[index];
+          if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+          return {
+            time: Math.floor(bar.date.getTime() / 1000) as UTCTimestamp,
+            value: v,
+          };
+        })
+        .filter((point: { time: UTCTimestamp; value: number } | null): point is { time: UTCTimestamp; value: number } => point !== null);
       ema200Series.setData(ema200Data);
       ema200SeriesRef.current = ema200Series;
 


### PR DESCRIPTION
Prevent EMA 20 and EMA 200 lines from rendering on the chart when insufficient data is available for accurate calculation.

Previously, EMA lines would incorrectly fall back to using the bar's closing price when the EMA value was undefined, leading to misleading line representations for early data points. This change ensures that EMA lines only appear from the first bar where a full period's worth of data allows for a correct EMA calculation.

---
<a href="https://cursor.com/background-agent?bcId=bc-81dc5038-0f06-4f0b-8207-13de9e55413b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81dc5038-0f06-4f0b-8207-13de9e55413b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

