### PR TITLE
Add margin to purchase at close tab

### DIFF
--- a/src/components/BuyAtCloseSimulator.tsx
+++ b/src/components/BuyAtCloseSimulator.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { EquityPoint, OHLCData, Strategy } from '../types';
 import { EquityChart } from './EquityChart';
 import { IndicatorEngine } from '../lib/indicators';
@@ -13,6 +13,31 @@ interface SimulationResult {
   finalValue: number;
   maxDrawdown: number;
   trades: number;
+}
+
+function simulateLeverage(equity: EquityPoint[], leverage: number): { equity: EquityPoint[]; finalValue: number; maxDrawdown: number } {
+  if (!equity || equity.length === 0 || leverage <= 0) {
+    return { equity: [], finalValue: 0, maxDrawdown: 0 };
+  }
+  const result: EquityPoint[] = [];
+  let currentValue = equity[0].value;
+  let peakValue = currentValue;
+  let maxDD = 0;
+  result.push({ date: equity[0].date, value: currentValue, drawdown: 0 });
+  for (let i = 1; i < equity.length; i++) {
+    const basePrev = equity[i - 1].value;
+    const baseCurr = equity[i].value;
+    if (basePrev <= 0) continue;
+    const baseReturn = (baseCurr - basePrev) / basePrev;
+    const leveragedReturn = baseReturn * leverage;
+    currentValue = currentValue * (1 + leveragedReturn);
+    if (currentValue < 0) currentValue = 0;
+    if (currentValue > peakValue) peakValue = currentValue;
+    const dd = peakValue > 0 ? ((peakValue - currentValue) / peakValue) * 100 : 0;
+    if (dd > maxDD) maxDD = dd;
+    result.push({ date: equity[i].date, value: currentValue, drawdown: dd });
+  }
+  return { equity: result, finalValue: result[result.length - 1]?.value ?? currentValue, maxDrawdown: maxDD };
 }
 
 function formatCurrencyUSD(value: number): string {
@@ -107,6 +132,8 @@ export function BuyAtCloseSimulator({ data, strategy }: BuyAtCloseSimulatorProps
   const [lowIbs, setLowIbs] = useState<string>('0.10');
   const [highIbs, setHighIbs] = useState<string>('0.75');
   const [maxHold, setMaxHold] = useState<string>('30');
+  const [marginPctInput, setMarginPctInput] = useState<string>('100');
+  const [appliedLeverage, setAppliedLeverage] = useState<number>(1);
 
   const effectiveStrategy: Strategy | null = useMemo(() => {
     if (!strategy) return null;
@@ -124,6 +151,36 @@ export function BuyAtCloseSimulator({ data, strategy }: BuyAtCloseSimulatorProps
     if (!data || !effectiveStrategy) return { equity: [], finalValue: 0, maxDrawdown: 0, trades: 0 };
     return simulateBuyAtClose(data, effectiveStrategy);
   }, [data, effectiveStrategy]);
+
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const fromUrl = params.get('margin');
+      const saved = localStorage.getItem('buyAtClose.marginPct');
+      const source = fromUrl ?? saved ?? undefined;
+      if (source) {
+        setMarginPctInput(source);
+        const pct = Number(source);
+        if (isFinite(pct) && pct > 0) setAppliedLeverage(pct / 100);
+      }
+    } catch {
+      // ignore persistence errors
+    }
+  }, []);
+
+  const onApplyMargin = () => {
+    const pct = Number(marginPctInput);
+    if (!isFinite(pct) || pct <= 0) return;
+    setAppliedLeverage(pct / 100);
+    try {
+      localStorage.setItem('buyAtClose.marginPct', String(pct));
+      const url = new URL(window.location.href);
+      url.searchParams.set('margin', String(pct));
+      window.history.replaceState(null, '', url.toString());
+    } catch { /* ignore */ }
+  };
+
+  const leveraged = useMemo(() => simulateLeverage(equity, appliedLeverage), [equity, appliedLeverage]);
 
   if (!effectiveStrategy) {
     return (
@@ -149,16 +206,31 @@ export function BuyAtCloseSimulator({ data, strategy }: BuyAtCloseSimulatorProps
           <label className="text-xs text-gray-600 dark:text-gray-300">Макс. дней удержания</label>
           <input type="number" step="1" min={1} value={maxHold} onChange={e => setMaxHold(e.target.value)} className="px-3 py-2 border rounded-md w-36 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100" />
         </div>
+        <div className="flex flex-col">
+          <label className="text-xs text-gray-600 dark:text-gray-300">Маржинальность, %</label>
+          <input
+            type="number"
+            inputMode="decimal"
+            min={1}
+            step={1}
+            value={marginPctInput}
+            onChange={(e) => setMarginPctInput(e.target.value)}
+            className="px-3 py-2 border rounded-md w-36 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+            placeholder="например, 100"
+          />
+        </div>
+        <button onClick={onApplyMargin} className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700">Посчитать</button>
         <div className="text-xs text-gray-500 dark:text-gray-300 ml-auto flex gap-3">
-          <span>Итог: {formatCurrencyUSD(finalValue)}</span>
-          <span>Макс. просадка: {maxDrawdown.toFixed(2)}%</span>
+          <span>Итог: {formatCurrencyUSD(leveraged.finalValue)}</span>
+          <span>Макс. просадка: {leveraged.maxDrawdown.toFixed(2)}%</span>
           <span>Сделок: {trades}</span>
           {(start && end) && <span>Период: {start} — {end}</span>}
+          <span>Текущее плечо: ×{appliedLeverage.toFixed(2)}</span>
         </div>
       </div>
 
       <div className="h-[600px]">
-        <EquityChart equity={equity} hideHeader />
+        <EquityChart equity={leveraged.equity} hideHeader />
       </div>
     </div>
   );


### PR DESCRIPTION
Add a margin input to the "Buy at Close" tab to apply leverage to the simulation results.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8da5c38-9a03-423f-a5ee-67f45f8afb44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8da5c38-9a03-423f-a5ee-67f45f8afb44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

