### PR TITLE
Fix null value calculation error

### DIFF
--- a/src/lib/clean-backtest.ts
+++ b/src/lib/clean-backtest.ts
@@ -269,22 +269,21 @@ export class CleanBacktestEngine {
       }
     }
 
-    // Добавляем последний equity point
+    // Обновляем последний equity point без дублирования временной метки
     let finalValue = this.currentCapital;
     if (position) {
       finalValue += position.quantity * lastBar.close;
     }
-
     const finalPeakValue = this.equity.length > 0 
       ? Math.max(...this.equity.map(e => e.value), finalValue)
       : finalValue;
     const finalDrawdown = finalPeakValue > 0 ? ((finalPeakValue - finalValue) / finalPeakValue) * 100 : 0;
-
-    this.equity.push({
-      date: lastBar.date,
-      value: finalValue,
-      drawdown: finalDrawdown
-    });
+    const lastIdx = this.equity.length - 1;
+    if (lastIdx >= 0 && this.equity[lastIdx].date.getTime() === lastBar.date.getTime()) {
+      this.equity[lastIdx] = { date: lastBar.date, value: finalValue, drawdown: finalDrawdown };
+    } else {
+      this.equity.push({ date: lastBar.date, value: finalValue, drawdown: finalDrawdown });
+    }
 
 
 


### PR DESCRIPTION
Implement data deduplication and validation for OHLC and equity series to prevent "Value is null" errors in lightweight-charts.

The `lightweight-charts` library throws "Value is null" errors when receiving data with duplicate timestamps or non-finite values. This PR introduces a `dedupeDailyOHLC` helper to consolidate multiple OHLC bars for the same day into a single bar (first open, max high, min low, last close, sum volume). It also ensures equity data is deduplicated by timestamp and validated for finite values, and fixes a bug where the `CleanBacktestEngine` could produce a duplicate last equity point. This ensures all valid data is used, but consolidated correctly for charting without errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe66e74d-2336-46ee-80a1-e5bd57b31074">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe66e74d-2336-46ee-80a1-e5bd57b31074">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

