### PR TITLE
Investigate closing purchase trade count discrepancy

### DIFF
--- a/src/components/BuyAtCloseSimulator.tsx
+++ b/src/components/BuyAtCloseSimulator.tsx
@@ -72,6 +72,25 @@ export function BuyAtCloseSimulator({ data, strategy }: BuyAtCloseSimulatorProps
   const [appliedLeverage, setAppliedLeverage] = useState<number>(1);
   const [showTrades, setShowTrades] = useState<boolean>(false);
 
+  // Sync local IBS thresholds with the current strategy by default
+  useEffect(() => {
+    if (!strategy) return;
+    try {
+      const li = Number((strategy.parameters as any)?.lowIBS ?? 0.1);
+      const hi = Number((strategy.parameters as any)?.highIBS ?? 0.75);
+      const mh = Number(
+        typeof (strategy.parameters as any)?.maxHoldDays === 'number'
+          ? (strategy.parameters as any)?.maxHoldDays
+          : strategy.riskManagement?.maxHoldDays ?? 30
+      );
+      if (Number.isFinite(li)) setLowIbs(li.toFixed(2));
+      if (Number.isFinite(hi)) setHighIbs(hi.toFixed(2));
+      if (Number.isFinite(mh)) setMaxHold(String(mh));
+    } catch {
+      // ignore
+    }
+  }, [strategy]);
+
   const effectiveStrategy: Strategy | null = useMemo(() => {
     if (!strategy) return null;
     const p = { ...strategy.parameters } as any;


### PR DESCRIPTION
Synchronize IBS and max hold parameters in `BuyAtCloseSimulator` to match the main strategy, resolving discrepancies in trade counts.

The "Buy at Close" section previously used hardcoded default values for IBS thresholds and max hold days, which often differed from the active strategy's parameters. This led to a significant difference in the number of trades reported compared to the main backtest. By syncing these parameters, the simulator now applies the same trading logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2547b3a-6d16-4ab3-9cc4-8108036424e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2547b3a-6d16-4ab3-9cc4-8108036424e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

