### PR TITLE
Revamp multi-ticker page tabs and default strategy

### DIFF
--- a/src/components/MultiTickerPage.tsx
+++ b/src/components/MultiTickerPage.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { Download, Settings } from 'lucide-react';
+import React, { useMemo, useRef, useState } from 'react';
+import { Settings } from 'lucide-react';
 import { useAppStore } from '../stores';
-import type { Strategy, OHLCData, Trade, EquityPoint } from '../types';
+import type { Strategy, OHLCData, Trade, EquityPoint, SplitEvent } from '../types';
 import { DatasetAPI } from '../lib/api';
 import { adjustOHLCForSplits, dedupeDailyOHLC } from '../lib/utils';
 import { IndicatorEngine } from '../lib/indicators';
@@ -9,11 +9,14 @@ import { MultiTickerChart } from './MultiTickerChart';
 import { EquityChart } from './EquityChart';
 import { TradesTable } from './TradesTable';
 import { runSinglePositionBacktest, optimizeTickerData, formatCurrencyCompact } from '../lib/singlePositionBacktest';
+import { MiniQuoteChart } from './MiniQuoteChart';
+import { createStrategyFromTemplate, STRATEGY_TEMPLATES } from '../lib/strategy';
 
 interface TickerData {
   ticker: string;
   data: OHLCData[];
   ibsValues: number[];
+  splits: SplitEvent[];
 }
 
 interface BacktestResults {
@@ -32,8 +35,36 @@ interface BacktestResults {
   };
 }
 
+function calculateTradeStats(trades: Trade[] = []) {
+  const totalTrades = trades.length;
+  let wins = 0;
+  let losses = 0;
+  let totalPnL = 0;
+  let totalDuration = 0;
+
+  trades.forEach(trade => {
+    const pnl = trade.pnl ?? 0;
+    if (pnl > 0) wins += 1;
+    if (pnl < 0) losses += 1;
+    totalPnL += pnl;
+    totalDuration += trade.duration ?? 0;
+  });
+
+  const winRate = totalTrades > 0 ? (wins / totalTrades) * 100 : 0;
+  const avgDuration = totalTrades > 0 ? totalDuration / totalTrades : 0;
+
+  return {
+    totalTrades,
+    wins,
+    losses,
+    breakeven: totalTrades - wins - losses,
+    totalPnL,
+    winRate,
+    avgDuration
+  };
+}
+
 export function MultiTickerPage() {
-  const [selectedStrategy, setSelectedStrategy] = useState<Strategy | null>(null);
   const [tickers, setTickers] = useState<string[]>(['AAPL', 'MSFT', 'GOOGL', 'AMZN']);
   const [tickersInput, setTickersInput] = useState<string>('AAPL, MSFT, GOOGL, AMZN');
   const [leveragePercent, setLeveragePercent] = useState(200);
@@ -41,50 +72,87 @@ export function MultiTickerPage() {
   const [error, setError] = useState<string | null>(null);
   const [backtestResults, setBacktestResults] = useState<BacktestResults | null>(null);
   const [tickersData, setTickersData] = useState<TickerData[]>([]);
-  const [activeTab, setActiveTab] = useState<'price' | 'equity' | 'trades' | 'tiles'>('price');
+  const [activeTab, setActiveTab] = useState<'price' | 'equity' | 'trades' | 'splits'>('price');
+  const [selectedTradeTicker, setSelectedTradeTicker] = useState<'all' | string>('all');
 
-  // Получаем стратегии из store
-  const strategies = useAppStore(s => s.strategies) || [];
   const currentStrategy = useAppStore(s => s.currentStrategy);
+  const fallbackStrategyRef = useRef<Strategy | null>(null);
 
-  // Используем текущую стратегию по умолчанию
-  useEffect(() => {
-    if (currentStrategy && !selectedStrategy) {
-      setSelectedStrategy(currentStrategy);
-    }
-  }, [currentStrategy, selectedStrategy]);
+  if (!fallbackStrategyRef.current) {
+    fallbackStrategyRef.current = createStrategyFromTemplate(STRATEGY_TEMPLATES[0]);
+  }
+
+  const activeStrategy = currentStrategy ?? fallbackStrategyRef.current;
+  const lowIBS = Number(activeStrategy?.parameters?.lowIBS ?? 0.1);
+  const highIBS = Number(activeStrategy?.parameters?.highIBS ?? 0.75);
+  const maxHoldDays = Number(
+    typeof activeStrategy?.parameters?.maxHoldDays === 'number'
+      ? activeStrategy.parameters.maxHoldDays
+      : activeStrategy?.riskManagement?.maxHoldDays ?? 30
+  );
+
+  const tradesByTicker = useMemo(() => {
+    if (!backtestResults?.trades) return {} as Record<string, Trade[]>;
+    return backtestResults.trades.reduce<Record<string, Trade[]>>((acc, trade) => {
+      const ticker = (trade.context?.ticker || '').toUpperCase();
+      if (!ticker) return acc;
+      if (!acc[ticker]) acc[ticker] = [];
+      acc[ticker].push(trade);
+      return acc;
+    }, {});
+  }, [backtestResults]);
+
+  const filteredTrades = useMemo(() => {
+    if (!backtestResults) return [] as Trade[];
+    if (selectedTradeTicker === 'all') return backtestResults.trades;
+    const targetTicker = (selectedTradeTicker || '').toUpperCase();
+    return backtestResults.trades.filter(
+      trade => (trade.context?.ticker || '').toUpperCase() === targetTicker
+    );
+  }, [backtestResults, selectedTradeTicker]);
+
+  const filteredTradeStats = useMemo(() => calculateTradeStats(filteredTrades), [filteredTrades]);
+
+  const totalSplitsCount = useMemo(
+    () => tickersData.reduce((sum, ticker) => sum + (ticker.splits?.length || 0), 0),
+    [tickersData]
+  );
 
   // Функция загрузки данных тикера
   const loadTickerData = async (ticker: string): Promise<TickerData> => {
     const ds = await DatasetAPI.getDataset(ticker);
+
+    const normalizedTicker = (ds.ticker || ticker).toUpperCase();
+
+    let splits: SplitEvent[] = [];
+    try {
+      splits = await DatasetAPI.getSplits(normalizedTicker);
+    } catch {
+      splits = [];
+    }
 
     let processedData: OHLCData[];
 
     if ((ds as any).adjustedForSplits) {
       processedData = dedupeDailyOHLC(ds.data as unknown as OHLCData[]);
     } else {
-      let splits: Array<{ date: string; factor: number }> = [];
-      try {
-        splits = await DatasetAPI.getSplits(ds.ticker);
-      } catch {
-        splits = [];
-      }
       processedData = dedupeDailyOHLC(adjustOHLCForSplits(ds.data as unknown as OHLCData[], splits));
     }
 
     const ibsValues = processedData.length > 0 ? IndicatorEngine.calculateIBS(processedData) : [];
 
     return {
-      ticker,
+      ticker: normalizedTicker,
       data: processedData,
-      ibsValues
+      ibsValues,
+      splits
     };
   };
 
   // Запуск бэктеста
   const runBacktest = async () => {
-    if (!selectedStrategy) {
-      setError('Выберите стратегию');
+    if (!activeStrategy) {
+      setError('Недоступна стратегия для запуска расчёта');
       return;
     }
 
@@ -106,7 +174,7 @@ export function MultiTickerPage() {
 
       // Run backtest with real logic
       const optimizedData = optimizeTickerData(loadedData);
-      const backtestResult = runSinglePositionBacktest(optimizedData, selectedStrategy, leveragePercent / 100);
+      const backtestResult = runSinglePositionBacktest(optimizedData, activeStrategy, leveragePercent / 100);
 
       const results: BacktestResults = {
         equity: backtestResult.equity,
@@ -125,6 +193,7 @@ export function MultiTickerPage() {
       };
 
       setBacktestResults(results);
+      setSelectedTradeTicker('all');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Ошибка при выполнении бэктеста');
       console.error('Backtest error:', err);
@@ -155,26 +224,36 @@ export function MultiTickerPage() {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-          {/* Выбор стратегии */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <div className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Стратегия
-            </label>
-            <select
-              value={selectedStrategy?.name || ''}
-              onChange={(e) => {
-                const strategy = strategies.find(s => s.name === e.target.value);
-                setSelectedStrategy(strategy || null);
-              }}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-            >
-              <option value="">Выберите стратегию</option>
-              {strategies.map(strategy => (
-                <option key={strategy.name} value={strategy.name}>
-                  {strategy.name}
-                </option>
-              ))}
-            </select>
+            </div>
+            <div className="h-full rounded-md border border-blue-200 bg-blue-50 p-4 text-sm dark:border-blue-900/60 dark:bg-blue-950/40">
+              <div className="text-base font-semibold text-blue-700 dark:text-blue-300">
+                {activeStrategy?.name || 'IBS Mean Reversion'}
+              </div>
+              <p className="mt-2 text-gray-700 dark:text-gray-200">
+                Вход при IBS ниже {Math.round(lowIBS * 100)}%, выход при превышении {Math.round(highIBS * 100)}% или по истечении {maxHoldDays} дн.
+              </p>
+              <dl className="mt-4 grid grid-cols-2 gap-3 text-xs text-gray-600 dark:text-gray-300">
+                <div>
+                  <dt className="uppercase tracking-wide">Риск-менеджмент</dt>
+                  <dd className="mt-1 font-medium text-gray-800 dark:text-gray-100">
+                    1 позиция • {activeStrategy?.riskManagement?.capitalUsage ?? 100}% капитала
+                  </dd>
+                </div>
+                <div>
+                  <dt className="uppercase tracking-wide">Комиссия</dt>
+                  <dd className="mt-1 font-medium text-gray-800 dark:text-gray-100">
+                    {activeStrategy?.riskManagement?.commission?.type === 'percentage'
+                      ? `${activeStrategy?.riskManagement?.commission?.percentage ?? 0}%`
+                      : activeStrategy?.riskManagement?.commission?.type === 'fixed'
+                        ? `$${activeStrategy?.riskManagement?.commission?.fixed ?? 0}`
+                        : 'Комбинированная'}
+                  </dd>
+                </div>
+              </dl>
+            </div>
           </div>
 
           {/* Тикеры */}
@@ -187,7 +266,12 @@ export function MultiTickerPage() {
               value={tickersInput}
               onChange={(e) => {
                 setTickersInput(e.target.value);
-                const parsedTickers = e.target.value.split(',').map(t => t.trim().toUpperCase()).filter(Boolean);
+                const parsedTickers = Array.from(new Set(
+                  e.target.value
+                    .split(',')
+                    .map(t => t.trim().toUpperCase())
+                    .filter(Boolean)
+                ));
                 setTickers(parsedTickers);
               }}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
@@ -214,6 +298,23 @@ export function MultiTickerPage() {
           </div>
         </div>
 
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+          <div className="md:col-span-3">
+            <div className="rounded-md border border-gray-200 bg-gray-50 p-4 text-sm dark:border-gray-700 dark:bg-gray-800/60">
+              <div className="flex flex-wrap items-center justify-between gap-2 text-gray-700 dark:text-gray-300">
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-gray-100">Текущие тикеры</p>
+                  <p className="font-mono text-sm">{tickers.join(', ') || '—'}</p>
+                </div>
+                <div className="text-right">
+                  <p>Торговое плечо: {(leveragePercent / 100).toFixed(1)}:1</p>
+                  <p>Максимум 1 позиция одновременно</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div className="flex items-center justify-between">
           <div className="text-sm text-gray-600 dark:text-gray-400">
             <p>Тикеры: <span className="font-mono">{tickers.join(', ')}</span></p>
@@ -222,7 +323,7 @@ export function MultiTickerPage() {
 
           <button
             onClick={runBacktest}
-            disabled={isLoading || !selectedStrategy || tickers.length === 0}
+            disabled={isLoading || !activeStrategy || tickers.length === 0}
             className="inline-flex items-center px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white font-medium rounded-md transition-colors"
           >
             {isLoading ? 'Расчёт...' : 'Запустить бэктест'}
@@ -301,7 +402,7 @@ export function MultiTickerPage() {
               { id: 'price' as const, label: '📈 Цены' },
               { id: 'equity' as const, label: '💰 Equity' },
               { id: 'trades' as const, label: '📊 Сделки' },
-              { id: 'tiles' as const, label: '🔢 Плитки' },
+              { id: 'splits' as const, label: '🪙 Сплиты' },
             ].map(tab => (
               <button
                 key={tab.id}
@@ -324,16 +425,93 @@ export function MultiTickerPage() {
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                   Индивидуальные графики цен
                 </h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {tickers.map(ticker => (
-                    <div key={ticker} className="h-48 bg-gray-50 dark:bg-gray-900/50 rounded border border-dashed border-gray-300 dark:border-gray-600 flex items-center justify-center">
-                      <div className="text-gray-500 dark:text-gray-400 text-center">
-                        <div className="font-medium">{ticker}</div>
-                        <div className="text-sm">График цены</div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                {tickersData.length === 0 ? (
+                  <div className="h-48 rounded border border-dashed border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 flex items-center justify-center text-gray-500 dark:text-gray-400">
+                    Нет данных для отображения. Запустите бэктест, чтобы загрузить котировки.
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                    {tickersData.map(tickerData => {
+                      const tradesForTicker = tradesByTicker[tickerData.ticker] || [];
+                      const stats = calculateTradeStats(tradesForTicker);
+                      const lastBar = tickerData.data[tickerData.data.length - 1];
+                      const prevBar = tickerData.data.length > 1 ? tickerData.data[tickerData.data.length - 2] : undefined;
+                      const dailyChange = lastBar && prevBar && prevBar.close !== 0
+                        ? ((lastBar.close - prevBar.close) / prevBar.close) * 100
+                        : null;
+
+                      return (
+                        <div
+                          key={tickerData.ticker}
+                          className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+                        >
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                              <div className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                                {tickerData.ticker}
+                              </div>
+                              <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                Баров: {tickerData.data.length}
+                              </div>
+                            </div>
+                            {lastBar && (
+                              <div className="text-right">
+                                <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                                  ${lastBar.close.toFixed(2)}
+                                </div>
+                                {dailyChange !== null && Number.isFinite(dailyChange) && (
+                                  <div className={`text-sm font-medium ${dailyChange >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-orange-500 dark:text-orange-400'}`}>
+                                    {dailyChange >= 0 ? '+' : ''}{dailyChange.toFixed(2)}%
+                                  </div>
+                                )}
+                                <div className="text-xs text-gray-500 dark:text-gray-400">
+                                  Обновлено {lastBar.date.toLocaleDateString('ru-RU')}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+
+                          <div className="mt-4 h-48">
+                            <MiniQuoteChart
+                              history={tickerData.data}
+                              today={null}
+                              trades={tradesForTicker}
+                              highIBS={highIBS}
+                              isOpenPosition={false}
+                            />
+                          </div>
+
+                          <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-gray-600 dark:text-gray-300">
+                            <div>
+                              <div className="text-xs uppercase tracking-wide">Сделок</div>
+                              <div className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100">
+                                {stats.totalTrades}
+                              </div>
+                            </div>
+                            <div>
+                              <div className="text-xs uppercase tracking-wide">Win rate</div>
+                              <div className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100">
+                                {stats.winRate.toFixed(1)}%
+                              </div>
+                            </div>
+                            <div>
+                              <div className="text-xs uppercase tracking-wide">PnL</div>
+                              <div className={`mt-1 text-base font-semibold ${stats.totalPnL >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-orange-500 dark:text-orange-300'}`}>
+                                {formatCurrencyCompact(stats.totalPnL)}
+                              </div>
+                            </div>
+                            <div>
+                              <div className="text-xs uppercase tracking-wide">Средняя длительность</div>
+                              <div className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-100">
+                                {stats.avgDuration.toFixed(1)} дн.
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             )}
 
@@ -362,32 +540,144 @@ export function MultiTickerPage() {
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                   История сделок ({backtestResults.trades.length})
                 </h3>
-                {backtestResults.trades.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    onClick={() => setSelectedTradeTicker('all')}
+                    className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                      selectedTradeTicker === 'all'
+                        ? 'bg-blue-600 text-white shadow-sm'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    Все ({backtestResults.trades.length})
+                  </button>
+                  {tickersData.map(tickerData => {
+                    const tradesForTicker = tradesByTicker[tickerData.ticker] || [];
+                    return (
+                      <button
+                        key={tickerData.ticker}
+                        onClick={() => setSelectedTradeTicker(tickerData.ticker)}
+                        className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                          selectedTradeTicker === tickerData.ticker
+                            ? 'bg-blue-600 text-white shadow-sm'
+                            : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+                        }`}
+                      >
+                        {tickerData.ticker} ({tradesForTicker.length})
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <div className="grid grid-cols-2 gap-4 rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm dark:border-gray-700 dark:bg-gray-900/40 md:grid-cols-4">
+                  <div>
+                    <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Сделок</div>
+                    <div className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">{filteredTradeStats.totalTrades}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Win rate</div>
+                    <div className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">{filteredTradeStats.winRate.toFixed(1)}%</div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">PnL</div>
+                    <div className={`mt-1 text-lg font-semibold ${filteredTradeStats.totalPnL >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-orange-500 dark:text-orange-300'}`}>
+                      {formatCurrencyCompact(filteredTradeStats.totalPnL)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Средняя длительность</div>
+                    <div className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">{filteredTradeStats.avgDuration.toFixed(1)} дн.</div>
+                  </div>
+                </div>
+
+                {filteredTrades.length > 0 ? (
                   <div className="max-h-[600px] overflow-auto">
-                    <TradesTable trades={backtestResults.trades} />
+                    <TradesTable trades={filteredTrades} />
                   </div>
                 ) : (
-                  <div className="h-96 bg-gray-50 dark:bg-gray-900/50 rounded border border-dashed border-gray-300 dark:border-gray-600 flex items-center justify-center">
+                  <div className="h-72 bg-gray-50 dark:bg-gray-900/50 rounded border border-dashed border-gray-300 dark:border-gray-600 flex items-center justify-center">
                     <div className="text-gray-500 dark:text-gray-400 text-center">
                       <div className="text-lg font-medium mb-2">📊 Trades Table</div>
-                      <p className="text-sm">Нет сделок для отображения</p>
+                      <p className="text-sm">Для выбранного тикера сделки отсутствуют</p>
                     </div>
                   </div>
                 )}
               </div>
             )}
 
-            {activeTab === 'tiles' && (
+            {activeTab === 'splits' && (
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                  Детальные метрики
-                </h3>
-                <div className="h-96 bg-gray-50 dark:bg-gray-900/50 rounded border border-dashed border-gray-300 dark:border-gray-600 flex items-center justify-center">
-                  <div className="text-gray-500 dark:text-gray-400 text-center">
-                    <div className="text-lg font-medium mb-2">🔢 Metrics Tiles</div>
-                    <p className="text-sm">Плитки с подробными метриками</p>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    История сплитов по тикерам
+                  </h3>
+                  <div className="text-sm text-gray-500 dark:text-gray-400">
+                    Всего сплитов: {totalSplitsCount}
                   </div>
                 </div>
+
+                {tickersData.length === 0 ? (
+                  <div className="h-48 rounded border border-dashed border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 flex items-center justify-center text-gray-500 dark:text-gray-400">
+                    Нет данных о сплитах. Запустите бэктест, чтобы загрузить истории тикеров.
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    {tickersData.map(tickerData => {
+                      const sortedSplits = [...(tickerData.splits || [])].sort((a, b) => b.date.localeCompare(a.date));
+                      const hasSplits = sortedSplits.length > 0;
+
+                      return (
+                        <div
+                          key={tickerData.ticker}
+                          className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <div>
+                              <div className="text-base font-semibold text-gray-900 dark:text-gray-100">{tickerData.ticker}</div>
+                              <div className="text-xs text-gray-500 dark:text-gray-400">
+                                {hasSplits ? `Найдено ${sortedSplits.length} ${sortedSplits.length === 1 ? 'событие' : 'событий'}` : 'Сплиты не найдены'}
+                              </div>
+                            </div>
+                            {hasSplits && (
+                              <div className="text-xs text-gray-500 dark:text-gray-400 text-right">
+                                Последний: {new Date(sortedSplits[0].date).toLocaleDateString('ru-RU')}
+                              </div>
+                            )}
+                          </div>
+
+                          <div className="mt-3 space-y-2">
+                            {hasSplits ? (
+                              sortedSplits.map((split, index) => (
+                                <div
+                                  key={`${tickerData.ticker}-${split.date}-${index}`}
+                                  className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                                >
+                                  <span className="font-mono">{new Date(split.date).toLocaleDateString('ru-RU')}</span>
+                                  <span className="font-semibold text-gray-900 dark:text-gray-100">Коэфф.: {split.factor}:1</span>
+                                </div>
+                              ))
+                            ) : (
+                              <div className="rounded-md bg-gray-50 px-3 py-3 text-sm text-gray-500 dark:bg-gray-800 dark:text-gray-300">
+                                Для этого тикера сплиты не найдены.
+                              </div>
+                            )}
+                          </div>
+
+                          <div className="mt-4 text-xs">
+                            <a
+                              href={`https://seekingalpha.com/symbol/${tickerData.ticker}/splits`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-blue-600 underline transition-colors hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                            >
+                              Подробнее о сплитах {tickerData.ticker}
+                            </a>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- remove the manual strategy selector on the multi-ticker page, automatically rely on the default IBS strategy, and surface its parameters in an info card
- rework the analytics tabs: render per-ticker price mini charts with stats, add ticker filters and summary metrics to the trades tab, and rename the tiles tab to show detailed split histories
- persist split data for each loaded ticker and deduplicate ticker input so the new split view stays in sync

## Testing
- npm run lint *(fails: existing lint warnings/errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d81b458c83289f8e82b37e1433f2