### PR TITLE
Fix incorrect trade date display in TradesTable

### DIFF
--- a/src/components/TradesTable.tsx
+++ b/src/components/TradesTable.tsx
@@ -16,13 +16,18 @@ export const TradesTable = React.memo(function TradesTable({ trades }: TradesTab
 		);
 	}
 
-	const fmtDate = (d: Date) => {
-		try {
-			return new Date(d).toLocaleDateString('ru-RU');
-		} catch {
-			return String(d);
-		}
-	};
+        const fmtDate = (d: Date | string | null | undefined) => {
+                if (!d) {
+                        return '—';
+                }
+
+                try {
+                        const date = typeof d === 'string' ? new Date(d) : d;
+                        return new Intl.DateTimeFormat('ru-RU', { timeZone: 'UTC' }).format(date);
+                } catch {
+                        return String(d);
+                }
+        };
 	return (
 		<div className="w-full overflow-auto">
 			<table className="min-w-full text-sm">


### PR DESCRIPTION
## Summary
- ensure trade dates in the table are formatted in UTC to avoid timezone shifts
- handle string or missing values safely when formatting dates

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3c2f27b30832885129562055a49b1