### PR TITLE
Reduce scheduler interval to 15 seconds

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2141,7 +2141,7 @@ async function runPriceActualization(options = {}) {
 setInterval(async () => {
   await runTelegramAggregation(null, {});
   await runPriceActualization({ source: 'scheduler' });
-}, 30000);
+}, 15000);
 
 // Test simulation endpoint to reproduce the logic as if at T-11 or T-1
 app.post('/api/telegram/simulate', async (req, res) => {


### PR DESCRIPTION
## Summary
- decrease the scheduler interval for Telegram aggregation and price actualization to run every 15 seconds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cd6027a48328a0dccb4f7c3a084e