### PR TITLE
feat: show latest trades first

### DIFF
--- a/src/components/MonitorTradeHistoryPanel.tsx
+++ b/src/components/MonitorTradeHistoryPanel.tsx
@@ -78,7 +78,7 @@ function TradeRow({ trade, isHighlighted }: { trade: MonitorTradeRecord; isHighl
 export function MonitorTradeHistoryPanel({ data, loading = false, error = null, onRefresh, maxRows = 10 }: MonitorTradeHistoryPanelProps) {
   const trades = data?.trades ?? [];
   const openTrade = data?.openTrade ?? null;
-  const rows = trades.slice(0, maxRows);
+  const rows = [...trades].reverse().slice(0, maxRows);
   const hasTrades = rows.length > 0;
 
   return (

--- a/src/components/TradesTable.tsx
+++ b/src/components/TradesTable.tsx
@@ -6,9 +6,13 @@ interface TradesTableProps {
 }
 
 export const TradesTable = React.memo(function TradesTable({ trades }: TradesTableProps) {
-	const showTicker = useMemo(() => {
-		return trades && trades.some(t => typeof (t.context as any)?.ticker === 'string' && (t.context as any)?.ticker);
-	}, [trades]);
+        const showTicker = useMemo(() => {
+                return trades && trades.some(t => typeof (t.context as any)?.ticker === 'string' && (t.context as any)?.ticker);
+        }, [trades]);
+
+        const reversedTrades = useMemo(() => {
+                return [...trades].reverse();
+        }, [trades]);
 
 	if (!trades || trades.length === 0) {
 		return (
@@ -48,7 +52,7 @@ export const TradesTable = React.memo(function TradesTable({ trades }: TradesTab
 					</tr>
 				</thead>
 				<tbody>
-					{trades.map((t, i) => {
+                                        {reversedTrades.map((t, i) => {
 						const positive = (t.pnl ?? 0) >= 0;
 						// Получаем IBS значения из контекста
 						const entryIBS = t.context?.indicatorValues?.IBS;


### PR DESCRIPTION
## Summary
- реверсировал отображение строк в общей таблице сделок, чтобы новые сделки показывались первыми
- изменил панель истории мониторинга, чтобы она также выводила последние сделки сверху

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e0602ef4832886c9c7f8469f6617