### PR TITLE
Update default multi-ticker selections to use MAGS

### DIFF
--- a/src/components/BuyAtClose4Simulator.tsx
+++ b/src/components/BuyAtClose4Simulator.tsx
@@ -526,7 +526,7 @@ function runMultiTickerBacktest(
   return { equity, finalValue, maxDrawdown, trades, metrics };
 }
 
-export function BuyAtClose4Simulator({ strategy, defaultTickers = ['AAPL', 'MSFT', 'GOOGL', 'TSLA'] }: BuyAtClose4SimulatorProps) {
+export function BuyAtClose4Simulator({ strategy, defaultTickers = ['AAPL', 'MSFT', 'AMZN', 'MAGS'] }: BuyAtClose4SimulatorProps) {
   const [tickers, setTickers] = useState<string[]>(defaultTickers);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -614,7 +614,7 @@ export function BuyAtClose4Simulator({ strategy, defaultTickers = ['AAPL', 'MSFT
             type="text"
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
-            placeholder="AAPL, MSFT, GOOGL, TSLA"
+            placeholder="AAPL, MSFT, AMZN, MAGS"
             className="flex-1 min-w-[300px] px-3 py-2 border rounded-md dark:bg-gray-900 dark:border-gray-600 dark:text-gray-100"
           />
           <button

--- a/src/components/BuyAtClose4Simulator_old.tsx
+++ b/src/components/BuyAtClose4Simulator_old.tsx
@@ -407,7 +407,7 @@ function runMultiTickerBacktest(
   return { equity, finalValue, maxDrawdown, trades, metrics };
 }
 
-export function BuyAtClose4Simulator({ strategy, defaultTickers = ['AAPL', 'MSFT', 'GOOGL', 'TSLA'] }: BuyAtClose4SimulatorProps) {
+export function BuyAtClose4Simulator({ strategy, defaultTickers = ['AAPL', 'MSFT', 'AMZN', 'MAGS'] }: BuyAtClose4SimulatorProps) {
   const [tickers, setTickers] = useState<string[]>(defaultTickers);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -494,7 +494,7 @@ export function BuyAtClose4Simulator({ strategy, defaultTickers = ['AAPL', 'MSFT
             type="text"
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
-            placeholder="AAPL, MSFT, GOOGL, TSLA"
+            placeholder="AAPL, MSFT, AMZN, MAGS"
             className="flex-1 min-w-[300px] px-3 py-2 border rounded-md dark:bg-gray-900 dark:border-gray-600 dark:text-gray-100"
           />
           <button

--- a/src/components/MultiTickerPage.tsx
+++ b/src/components/MultiTickerPage.tsx
@@ -70,8 +70,8 @@ function calculateTradeStats(trades: Trade[] = []) {
 }
 
 export function MultiTickerPage() {
-  const [tickers, setTickers] = useState<string[]>(['AAPL', 'MSFT', 'GOOGL', 'AMZN']);
-  const [tickersInput, setTickersInput] = useState<string>('AAPL, MSFT, GOOGL, AMZN');
+  const [tickers, setTickers] = useState<string[]>(['AAPL', 'MSFT', 'AMZN', 'MAGS']);
+  const [tickersInput, setTickersInput] = useState<string>('AAPL, MSFT, AMZN, MAGS');
   const [leveragePercent, setLeveragePercent] = useState(200);
   const [monthlyContributionAmount, setMonthlyContributionAmount] = useState<number>(500);
   const [monthlyContributionDay, setMonthlyContributionDay] = useState<number>(1);
@@ -344,7 +344,7 @@ export function MultiTickerPage() {
                 setTickers(parsedTickers);
               }}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-              placeholder="AAPL, MSFT, GOOGL, AMZN"
+              placeholder="AAPL, MSFT, AMZN, MAGS"
             />
           </div>
 

--- a/src/components/SinglePositionSimulator.tsx
+++ b/src/components/SinglePositionSimulator.tsx
@@ -529,8 +529,8 @@ export function SinglePositionSimulator({ strategy }: SinglePositionSimulatorPro
   } | null>(null);
   
   // Настройки стратегии
-  const [tickers, setTickers] = useState<string[]>(['AAPL', 'MSFT', 'GOOGL', 'AMZN']);
-  const [tickersInput, setTickersInput] = useState<string>('AAPL, MSFT, GOOGL, AMZN');
+  const [tickers, setTickers] = useState<string[]>(['AAPL', 'MSFT', 'AMZN', 'MAGS']);
+  const [tickersInput, setTickersInput] = useState<string>('AAPL, MSFT, AMZN, MAGS');
   const [leveragePercent, setLeveragePercent] = useState(200); // 200% = 2:1 leverage
 
   // Функция экспорта данных в JSON
@@ -649,7 +649,7 @@ export function SinglePositionSimulator({ strategy }: SinglePositionSimulatorPro
                 setTickers(parsedTickers);
               }}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-              placeholder="AAPL, MSFT, GOOGL, AMZN"
+              placeholder="AAPL, MSFT, AMZN, MAGS"
             />
           </div>
           


### PR DESCRIPTION
## Summary
- update default multi-ticker selections to use AAPL, MSFT, AMZN, and MAGS across simulators and the multi-ticker page
- adjust placeholder examples to reflect the new default symbols

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3e13b59848328826b79aa84e76adf