### PR TITLE
Добавлена пагинация таблицы сделок

### DIFF
--- a/src/components/TradesTable.tsx
+++ b/src/components/TradesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { Trade } from '../types';
 
 interface TradesTableProps {
@@ -6,6 +6,9 @@ interface TradesTableProps {
 }
 
 export const TradesTable = React.memo(function TradesTable({ trades }: TradesTableProps) {
+        const PAGE_SIZE = 50;
+        const [page, setPage] = useState(1);
+
         const showTicker = useMemo(() => {
                 return trades && trades.some(t => typeof (t.context as any)?.ticker === 'string' && (t.context as any)?.ticker);
         }, [trades]);
@@ -14,10 +17,34 @@ export const TradesTable = React.memo(function TradesTable({ trades }: TradesTab
                 return [...trades].reverse();
         }, [trades]);
 
-	if (!trades || trades.length === 0) {
-		return (
-			<div className="text-sm text-gray-500">Нет сделок для отображения</div>
-		);
+        const totalPages = useMemo(() => {
+                if (!reversedTrades || reversedTrades.length === 0) {
+                        return 1;
+                }
+
+                return Math.max(1, Math.ceil(reversedTrades.length / PAGE_SIZE));
+        }, [reversedTrades]);
+
+        useEffect(() => {
+                setPage(1);
+        }, [trades]);
+
+        useEffect(() => {
+                if (page > totalPages) {
+                        setPage(totalPages);
+                }
+        }, [page, totalPages]);
+
+        const paginatedTrades = useMemo(() => {
+                const start = (page - 1) * PAGE_SIZE;
+                const end = start + PAGE_SIZE;
+                return reversedTrades.slice(start, end);
+        }, [page, reversedTrades]);
+
+        if (!trades || trades.length === 0) {
+                return (
+                        <div className="text-sm text-gray-500">Нет сделок для отображения</div>
+                );
 	}
 
         const fmtDate = (d: Date | string | null | undefined) => {
@@ -52,11 +79,11 @@ export const TradesTable = React.memo(function TradesTable({ trades }: TradesTab
 					</tr>
 				</thead>
 				<tbody>
-                                        {reversedTrades.map((t, i) => {
-						const positive = (t.pnl ?? 0) >= 0;
-						// Получаем IBS значения из контекста
-						const entryIBS = t.context?.indicatorValues?.IBS;
-						const exitIBS = t.context?.indicatorValues?.exitIBS;
+                                        {paginatedTrades.map((t, i) => {
+                                                const positive = (t.pnl ?? 0) >= 0;
+                                                // Получаем IBS значения из контекста
+                                                const entryIBS = t.context?.indicatorValues?.IBS;
+                                                const exitIBS = t.context?.indicatorValues?.exitIBS;
 						
 						// Проверяем проблемы с IBS для цветовой индикации
 						const hasEntryProblem = typeof entryIBS === 'number' && entryIBS > 0.1;
@@ -70,8 +97,8 @@ export const TradesTable = React.memo(function TradesTable({ trades }: TradesTab
 						}
 						
 						return (
-							<tr key={t.id || i} className="border-b last:border-b-0 dark:border-gray-800">
-								<td className="px-3 py-2 text-gray-500">{i + 1}</td>
+                                                        <tr key={t.id || `${t.entryDate}-${t.exitDate}-${i}`} className="border-b last:border-b-0 dark:border-gray-800">
+                                                                <td className="px-3 py-2 text-gray-500">{(page - 1) * PAGE_SIZE + i + 1}</td>
 								{showTicker && <td className="px-3 py-2 whitespace-nowrap text-gray-700 dark:text-gray-200">{(t.context as any)?.ticker || ''}</td>}
 								<td className={`px-3 py-2 whitespace-nowrap ${hasIBSProblem ? 'bg-orange-50 dark:bg-orange-950/20' : ''}`}>
 									<div>{fmtDate(t.entryDate)} - {fmtDate(t.exitDate)}</div>
@@ -95,9 +122,36 @@ export const TradesTable = React.memo(function TradesTable({ trades }: TradesTab
 								<td className="px-3 py-2 whitespace-nowrap">{formattedExitReason}</td>
 							</tr>
 						);
-					})}
-				</tbody>
-			</table>
-		</div>
-	);
+                                        })}
+                                </tbody>
+                        </table>
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mt-4 text-sm text-gray-600 dark:text-gray-300">
+                                <div>
+                                        Показаны {(page - 1) * PAGE_SIZE + 1}–
+                                        {Math.min(page * PAGE_SIZE, reversedTrades.length)} из {reversedTrades.length} сделок
+                                </div>
+                                <div className="flex items-center gap-3">
+                                        <button
+                                                type="button"
+                                                className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100 dark:hover:bg-gray-800"
+                                                onClick={() => setPage(prev => Math.max(1, prev - 1))}
+                                                disabled={page <= 1}
+                                        >
+                                                Назад
+                                        </button>
+                                        <span>
+                                                Страница {page} из {totalPages}
+                                        </span>
+                                        <button
+                                                type="button"
+                                                className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100 dark:hover:bg-gray-800"
+                                                onClick={() => setPage(prev => Math.min(totalPages, prev + 1))}
+                                                disabled={page >= totalPages}
+                                        >
+                                                Вперёд
+                                        </button>
+                                </div>
+                        </div>
+                </div>
+        );
 });


### PR DESCRIPTION
## Summary
- добавить постраничный вывод по 50 сделок в компоненте `TradesTable` и обновить нумерацию
- показать пользователю диапазон отображаемых сделок и элементы управления навигацией

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3e15580d08328baf45be918543023