### PR TITLE
feat: улучшить пагинацию и экспорт сделок

### DIFF
--- a/src/components/BuyAtClose4Simulator.tsx
+++ b/src/components/BuyAtClose4Simulator.tsx
@@ -753,7 +753,10 @@ export function BuyAtClose4Simulator({ strategy, defaultTickers = ['AAPL', 'MSFT
               />
               
               <div className="max-h-[600px] overflow-auto">
-                <TradesTable trades={backtest.trades} />
+                <TradesTable
+                  trades={backtest.trades}
+                  exportFileNamePrefix="trades-buy-at-close-v2"
+                />
               </div>
             </div>
           )}

--- a/src/components/BuyAtClose4Simulator_old.tsx
+++ b/src/components/BuyAtClose4Simulator_old.tsx
@@ -597,7 +597,10 @@ export function BuyAtClose4Simulator({ strategy, defaultTickers = ['AAPL', 'MSFT
               />
               
               <div className="max-h-[600px] overflow-auto">
-                <TradesTable trades={backtest.trades} />
+                <TradesTable
+                  trades={backtest.trades}
+                  exportFileNamePrefix="trades-buy-at-close-v1"
+                />
               </div>
             </div>
           )}

--- a/src/components/BuyAtCloseSimulator.tsx
+++ b/src/components/BuyAtCloseSimulator.tsx
@@ -306,7 +306,10 @@ export function BuyAtCloseSimulator({ data, strategy }: BuyAtCloseSimulatorProps
             }}
           />
           
-          <TradesTable trades={tradesList} />
+          <TradesTable
+            trades={tradesList}
+            exportFileNamePrefix="trades-buy-at-close"
+          />
         </div>
       )}
     </div>

--- a/src/components/MultiTickerPage.tsx
+++ b/src/components/MultiTickerPage.tsx
@@ -706,7 +706,10 @@ export function MultiTickerPage() {
                 {filteredTrades.length > 0 ? (
                   <div className="-mx-6 overflow-x-auto">
                     <div className="min-w-full px-6">
-                      <TradesTable trades={filteredTrades} />
+                      <TradesTable
+                        trades={filteredTrades}
+                        exportFileNamePrefix={`trades-${selectedTradeTicker === 'all' ? 'all-tickers' : selectedTradeTicker}`}
+                      />
                     </div>
                   </div>
                 ) : (
@@ -845,7 +848,10 @@ export function MultiTickerPage() {
                     {monthlyContributionResults.trades.length > 0 ? (
                       <div className="-mx-6 overflow-x-auto">
                         <div className="min-w-full px-6">
-                          <TradesTable trades={monthlyContributionResults.trades} />
+                          <TradesTable
+                            trades={monthlyContributionResults.trades}
+                            exportFileNamePrefix={`trades-monthly-contribution-${monthlyContributionAmount}`}
+                          />
                         </div>
                       </div>
                     ) : (

--- a/src/components/NoStopLossSimulator.tsx
+++ b/src/components/NoStopLossSimulator.tsx
@@ -315,7 +315,10 @@ export function NoStopLossSimulator({ data, strategy }: NoStopLossSimulatorProps
             }}
           />
           
-          <TradesTable trades={result.trades} />
+          <TradesTable
+            trades={result.trades}
+            exportFileNamePrefix="trades-no-stop-loss"
+          />
         </div>
       )}
     </div>

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Heart, RefreshCcw, AlertTriangle, Loader2, Download } from 'lucide-react';
+import { Heart, RefreshCcw, AlertTriangle, Loader2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { DatasetAPI } from '../lib/api';
 import { formatOHLCYMD } from '../lib/utils';
@@ -832,30 +832,10 @@ export function Results() {
             )}
             {activeChart === 'trades' && (
               <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div className="text-sm text-gray-600 dark:text-gray-400">
-                    Всего сделок: {trades.length}
-                  </div>
-                  <button
-                    onClick={() => {
-                      const dataStr = JSON.stringify(trades, null, 2);
-                      const blob = new Blob([dataStr], { type: 'application/json' });
-                      const url = URL.createObjectURL(blob);
-                      const link = document.createElement('a');
-                      link.href = url;
-                      link.download = `trades-${symbol || 'backtest'}-${new Date().toISOString().slice(0, 10)}.json`;
-                      document.body.appendChild(link);
-                      link.click();
-                      document.body.removeChild(link);
-                      URL.revokeObjectURL(url);
-                    }}
-                    className="inline-flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 rounded-md bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 transition-colors"
-                  >
-                    <Download className="w-4 h-4" />
-                    Скачать JSON
-                  </button>
-                </div>
-                <TradesTable trades={trades} />
+                <TradesTable
+                  trades={trades}
+                  exportFileNamePrefix={`trades-${symbol || 'backtest'}`}
+                />
               </div>
             )}
             {activeChart === 'profit' && (

--- a/src/components/SinglePositionSimulator.tsx
+++ b/src/components/SinglePositionSimulator.tsx
@@ -801,7 +801,10 @@ export function SinglePositionSimulator({ strategy }: SinglePositionSimulatorPro
               />
               
               <div className="max-h-[600px] overflow-auto">
-                <TradesTable trades={backtest.trades} />
+                <TradesTable
+                  trades={backtest.trades}
+                  exportFileNamePrefix="trades-single-position"
+                />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- добавлена расширенная пагинация с переходами к первой и последней страницам для всех таблиц сделок
- встроен экспорт сделок в JSON в компонент таблицы и подключен на всех страницах со списками сделок
- скорректированы страницы стратегий и результатов для использования новой таблицы

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3e4549dd08328abb05cdf874e75a5