### PR TITLE
Migrate chart layer to lightweight-charts v5 and implement full audit fixes

### DIFF
--- a/LIGHTWEIGHT_CHARTS_DOCS_NOTES.md
+++ b/LIGHTWEIGHT_CHARTS_DOCS_NOTES.md
@@ -1,0 +1,54 @@
+# Lightweight Charts: ключевая выжимка документации
+
+Дата обзора: 2026-02-14
+
+## Источники
+- Официальные tutorial'ы: <https://tradingview.github.io/lightweight-charts/tutorials>
+- API/Docs: <https://tradingview.github.io/lightweight-charts/docs>
+- Миграция v4->v5: <https://tradingview.github.io/lightweight-charts/docs/migrations/from-v4-to-v5>
+- What is new in v5: <https://tradingview.github.io/lightweight-charts/docs/release-notes#whats-new-in-50>
+- GitHub репозиторий: <https://github.com/tradingview/lightweight-charts>
+- README (raw): <https://raw.githubusercontent.com/tradingview/lightweight-charts/master/README.md>
+
+## 1. Базовая модель библиотеки
+- Chart создается через `createChart(container, options)`.
+- Основная работа с данными идет через series (`Candlestick`, `Line`, `Area`, `Histogram`, `Baseline`).
+- Серии принимают `setData([...])` для полной загрузки и `update(point)` для инкрементальных real-time апдейтов.
+- Взаимодействие (hover/tooltip/legend) строится через подписки типа `subscribeCrosshairMove(handler)`.
+
+## 2. Важные практики из tutorial'ов
+- Разделение цены и объема: делать volume отдельной `Histogram`-серией, обычно с `priceScaleId: ''` и `scaleMargins`, чтобы цена и объем не мешали друг другу.
+- Tooltips/Legend: обновлять UI по `subscribeCrosshairMove`, держать tooltip `pointer-events: none`, скрывать при выходе курсора/пустых данных.
+- Две шкалы цен: использовать `leftPriceScale`/`rightPriceScale` и `priceScaleId` для разных серий.
+- Синхронизация графиков: использовать `setCrosshairPosition`/`clearCrosshairPosition` и синхронизацию диапазона по `timeScale()`.
+- Realtime: при добавлении новых баров использовать `series.update(...)` вместо полного `setData(...)`.
+- Infinite history/lazy-load: реагировать на `subscribeVisibleLogicalRangeChange`, подгружать историю при приближении к левому краю диапазона.
+- Кастомизация локали/форматирования: через `localization`, `priceFormat`, `timeScale` форматтеры.
+
+## 3. React-интеграция (из tutorial'ов)
+- Хранить chart/series в `useRef`.
+- Инициализировать chart в `useEffect` после монтирования контейнера.
+- В cleanup обязательно делать отписки и `chart.remove()`.
+- На ресайз корректно обновлять размеры chart (предпочтительно через `ResizeObserver`/`autoSize`, а не только через `window.resize`).
+
+## 4. Производительность и стабильность
+- Для live-режимов минимизировать полные перерисовки (`setData`) и переходить к `update`.
+- Держать единый формат времени (UTC timestamp или business day) без смешивания разных преобразований по коду.
+- Передавать уже валидированные/отсортированные данные, чтобы не сортировать на каждом рендере.
+- Убирать лишние DOM-оверлеи поверх canvas, где возможно (или строго контролировать их lifecycle).
+
+## 5. Что важно по версиям (v4 vs v5)
+- В v5 введен более унифицированный API добавления серий (`addSeries(...)`), улучшена tree-shaking модель и появились новые возможности.
+- В v5 есть изменения в API маркеров/кастомных серий, которые нужно учитывать при миграции с v4.
+- Практически: если кодовая база на v4, а команда ориентируется на текущие tutorial'ы v5, лучше планово мигрировать, чтобы не копить несовместимые паттерны.
+
+## 6. Ограничения и лицензирование
+- Проект open-source (Apache-2.0), но README отдельно напоминает про ограничения использования торговых марок TradingView.
+- Перед публичным коммерческим использованием UI/branding стоит проверить актуальные условия из README/NOTICE.
+
+## 7. Мини-чеклист для команды
+- Используем ли везде единый конвертер даты для графиков?
+- Где можно заменить `setData` на `update`?
+- Везде ли корректный cleanup подписок?
+- Нет ли массового пересоздания chart при каждом изменении данных?
+- Готов ли слой графиков к переходу на v5 API?

--- a/STOCK_CHARTS_AUDIT.md
+++ b/STOCK_CHARTS_AUDIT.md
@@ -1,0 +1,168 @@
+# Аудит графиков акций по страницам сайта
+
+Дата аудита: 2026-02-14
+Формат: статический аудит кода + сверка с актуальной документацией Lightweight Charts.
+
+## Что проверено
+- Роуты и вкладки, где отрисовываются графики.
+- Все компоненты на `lightweight-charts`.
+- Текущая версия библиотеки и совместимость с актуальной документацией.
+- Технические риски: lifecycle, даты/время, resize, производительность, тестовое покрытие.
+
+Проверка сборки:
+- `npm run -s build:check` -> есть ошибки компиляции (в т.ч. в графическом коде).
+
+## Карта графиков по страницам
+- `/results` (SingleTickerPage):
+- `TradingChart` (цена)
+- `EquityChart` (equity)
+- `TradeDrawdownChart` (просадка)
+- `ProfitFactorAnalysis`
+- `DurationAnalysis`
+- `OpenDayDrawdownChart`
+- `MiniQuoteChart` внутри `TickerCard`
+
+- `/multi-ticker`:
+- `MultiTickerChart` (сводный график)
+- `EquityChart`
+- `TradeDrawdownChart`
+- `ProfitFactorAnalysis`
+- `DurationAnalysis`
+- `MiniQuoteChart` в `TickerCardsGrid`
+
+- `/multi-ticker-options`:
+- тот же набор, что и `/multi-ticker`, через `BacktestResultsView`.
+
+Точки подключения:
+- `src/components/AppRouter.tsx:355`
+- `src/components/AppRouter.tsx:356`
+- `src/components/AppRouter.tsx:357`
+- `src/components/BacktestResultsView.tsx:127`
+- `src/components/BacktestResultsView.tsx:152`
+- `src/components/BacktestResultsView.tsx:191`
+- `src/components/BacktestResultsView.tsx:208`
+- `src/components/BacktestResultsView.tsx:320`
+- `src/components/BacktestResultsView.tsx:335`
+- `src/components/TickerCard.tsx:116`
+
+## Ключевые находки (по приоритету)
+
+### P1. Текущая версия библиотеки отстает от актуальной документации
+- В проекте зафиксировано `lightweight-charts@^4.2.3`.
+- Файл: `package.json:26`
+- Риск: команда ориентируется на актуальные tutorial'ы (v5), но API/паттерны в коде частично v4-специфичны; это тормозит развитие и усложняет поддержку.
+
+### P1. Есть ошибка type-check в графическом коде
+- Ошибка `TS2722` на вызове `series.setMarkers(...)`.
+- Файл: `src/components/MiniQuoteChart.tsx:193`
+- Подтверждено командой `npm run -s build:check`.
+- Риск: strict TypeScript-сборка не проходит.
+
+### P2. Неправильная модель отписки от crosshair-событий
+- В коде сохраняется результат `subscribeCrosshairMove(...)` как будто это функция отписки.
+- Фактически API использует парный вызов `unsubscribeCrosshairMove(handler)`.
+- Файлы:
+- `src/components/TradingChart.tsx:224`
+- `src/components/TradingChart.tsx:250`
+- `src/components/EquityChart.tsx:199`
+- `src/components/EquityChart.tsx:227`
+- Риск: хрупкий lifecycle и потенциальные утечки обработчиков при дальнейших рефакторингах.
+
+### P2. Несогласованное преобразование времени между компонентами
+- Часть графиков использует `toChartTimestamp(...)`, часть - `new Date(...).getTime()/1000`.
+- Примеры:
+- `src/components/TradingChart.tsx:385`
+- `src/components/MultiTickerChart.tsx:86`
+- `src/components/TradeDrawdownChart.tsx:89`
+- `src/components/OpenDayDrawdownChart.tsx:39`
+- `src/components/ProfitFactorAnalysis.tsx:63`
+- `src/components/DurationAnalysis.tsx:97`
+- Риск: смещения по дням/меткам на разных таймзонах, несинхронная визуализация между вкладками.
+
+### P2. Массовое пересоздание chart-instance при обновлениях данных
+- Несколько компонентов удаляют и создают chart заново при изменении массивов данных.
+- Пример:
+- `src/components/EquityChart.tsx:246` (зависимость эффекта от `equity` и `comparisonEquity`)
+- `src/components/MultiTickerChart.tsx:337` (зависимость от `preparedTickersData`/`markersByTicker`)
+- `src/components/TradeDrawdownChart.tsx:152`
+- `src/components/ProfitFactorAnalysis.tsx:91`
+- `src/components/DurationAnalysis.tsx:129`
+- Риск: лишняя нагрузка, скачки UI, лишняя GC-активность на больших наборах данных.
+
+### P2. Каждый график вешает собственный `window.resize` listener
+- Файлы:
+- `src/components/TradingChart.tsx:241`
+- `src/components/EquityChart.tsx:218`
+- `src/components/MultiTickerChart.tsx:306`
+- `src/components/MiniQuoteChart.tsx:140`
+- `src/components/TradeDrawdownChart.tsx:136`
+- `src/components/OpenDayDrawdownChart.tsx:95`
+- `src/components/ProfitFactorAnalysis.tsx:86`
+- `src/components/DurationAnalysis.tsx:124`
+- Риск: дублирование логики ресайза и деградация производительности на сложных экранах.
+
+### P3. Неполное покрытие тестами именно chart-поведения
+- `TradingChart` тестирует только факт рендера.
+- Файл: `src/components/__tests__/TradingChart.test.tsx:6`
+- Нет полноценной проверки поведения crosshair, маркеров, тайм-конверсии, cleanup, theme switch и resize.
+
+## Аудит по страницам
+
+### 1) `/results` (один тикер)
+Сильные стороны:
+- Богатый набор графиков для анализа стратегии.
+- Есть тултипы, маркеры вход/выход, настройки индикаторов.
+
+Проблемы:
+- В `TradingChart` индикаторы IBS и Volume взаимоисключающие (`showIBS` vs `showVolume`), что ограничивает анализ свечей+объема.
+- В `EquityChart` и аналитических графиках частое пересоздание chart-instance.
+- Непоследовательная дата-модель между вкладками.
+
+Рекомендации:
+- Перейти на единый конвертер времени (`toChartTimestamp`) для всех chart-компонентов.
+- Для realtime-обновлений котировок использовать `series.update(...)`, а не полную замену данных.
+- Добавить диапазоны (`1M/3M/6M/YTD/1Y/ALL`) и сохранение выбранного диапазона в URL/сторе.
+
+### 2) `/multi-ticker`
+Сильные стороны:
+- Есть обзорный мульти-график и карточки по каждому тикеру.
+
+Проблемы:
+- `MultiTickerChart` при росте числа тикеров становится визуально перегруженным.
+- DOM-оверлеи с лейблами в самом контейнере усложняют lifecycle.
+- При каждом крупном обновлении данных chart пересоздается.
+
+Рекомендации:
+- Добавить ограничение на число одновременно отображаемых тикеров + пагинацию/чекбоксы выбора.
+- Сделать альтернативный режим сравнения: normalized line chart (база 100).
+- Вынести легенду в React UI, не рисовать DOM-лейблы поверх графика вручную.
+
+### 3) `/multi-ticker-options`
+Проблемы и риски аналогичны `/multi-ticker`, поскольку используется тот же слой визуализации (`BacktestResultsView`).
+
+Рекомендации:
+- Переиспользовать единый chart-core слой и общие утилиты дат/resize/lifecycle.
+- Сфокусироваться на одинаковом UX между multi и options, чтобы избежать расхождений поведения.
+
+## Варианты улучшений
+
+### Вариант A: Быстрая стабилизация (2-4 дня)
+- Исправить type-check ошибки (`MiniQuoteChart`, смежные TS-ошибки).
+- Привести подписки на crosshair к корректной схеме `subscribe/unsubscribe`.
+- Унифицировать time conversion во всех графиках.
+- Добавить smoke-тесты на ключевые chart-компоненты.
+
+### Вариант B: Производительность + UX (1 спринт)
+- Убрать массовое пересоздание chart при апдейтах данных (инициализация один раз, далее `setData/update/applyOptions`).
+- Централизовать resize (общий hook + `ResizeObserver`/`autoSize`).
+- Добавить range-switcher и улучшить мульти-тикерный UX (нормализация, фильтры, лимиты).
+
+### Вариант C: Плановая миграция на v5 (1-2 спринта)
+- Обновить библиотеку до v5.
+- Перевести код на актуальный API добавления серий/маркеров.
+- Использовать новые возможности v5 (в т.ч. более чистая архитектура серий/панелей) и убрать v4-технический долг.
+
+## Рекомендованный порядок
+1. Сначала Вариант A (устранить блокеры качества/сборки).
+2. Затем Вариант B (ускорить UI и улучшить аналитику для пользователя).
+3. После стабилизации - Вариант C (миграция на v5 как отдельная управляемая задача).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "fs-extra": "^11.3.3",
-        "lightweight-charts": "^4.2.3",
+        "lightweight-charts": "^5.1.0",
         "lucide-react": "^0.536.0",
         "papaparse": "^5.4.1",
         "react": "^19.1.0",
@@ -4143,10 +4143,9 @@
       }
     },
     "node_modules/lightweight-charts": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.2.3.tgz",
-      "integrity": "sha512-5kS/2hY3wNYNzhnS8Gb+GAS07DX8GPF2YVDnd2NMC85gJVQ6RLU6YrXNgNJ6eg0AnWPwCnvaGtYmGky3HiLQEw==",
-      "license": "Apache-2.0",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.1.0.tgz",
+      "integrity": "sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==",
       "dependencies": {
         "fancy-canvas": "2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "fs-extra": "^11.3.3",
-    "lightweight-charts": "^4.2.3",
+    "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.536.0",
     "papaparse": "^5.4.1",
     "react": "^19.1.0",

--- a/src/components/MiniQuoteChart.tsx
+++ b/src/components/MiniQuoteChart.tsx
@@ -1,12 +1,24 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { createChart, type IChartApi, type ISeriesApi, type IPriceLine, type UTCTimestamp } from 'lightweight-charts';
+import {
+  CandlestickSeries,
+  createChart,
+  createSeriesMarkers,
+  type IChartApi,
+  type IPriceLine,
+  type ISeriesApi,
+  type ISeriesMarkersPluginApi,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
 import type { OHLCData, Trade } from '../types';
+import { toChartTimestamp } from '../lib/date-utils';
 
 interface MiniQuoteChartProps {
   history: OHLCData[];
   today: { open: number | null; high: number | null; low: number | null; current: number | null } | null;
   trades: Trade[];
-  highIBS: number; // 0..1
+  highIBS: number;
   isOpenPosition: boolean;
   entryPrice?: number | null;
 }
@@ -15,103 +27,124 @@ export function MiniQuoteChart({ history, today, trades, highIBS, isOpenPosition
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+  const markersApiRef = useRef<ISeriesMarkersPluginApi<Time> | null>(null);
 
-  // Track price lines to remove them before updating
   const targetLineRef = useRef<IPriceLine | null>(null);
   const entryLineRef = useRef<IPriceLine | null>(null);
 
-  const [isDark, setIsDark] = useState<boolean>(() => typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false);
+  const [isDark, setIsDark] = useState<boolean>(() =>
+    typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false
+  );
 
-  // 1. Data Preparation (Memoized)
   const candles = useMemo(() => {
-    // If history is empty and no today data, return empty array
     const hasToday = !!(today && today.low != null && today.high != null && today.open != null && today.current != null);
     if (!history.length && !hasToday) return [];
 
-    // TickerCard already slices history, but we do it again just in case or for safety
-    // Optimization: Avoid expensive Date parsing in sort if possible, but history usually small here.
-    const sorted = [...history].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    const sorted = [...history].sort((a, b) => {
+      const ta = toChartTimestamp(a.date) as number;
+      const tb = toChartTimestamp(b.date) as number;
+      return ta - tb;
+    });
+
     const historyCount = hasToday ? 20 : 21;
     const lastHistory = sorted.slice(-historyCount);
 
-    const data = lastHistory.map(b => ({
-      time: Math.floor(new Date(b.date).getTime() / 1000) as UTCTimestamp,
-      open: b.open, high: b.high, low: b.low, close: b.close,
+    const data = lastHistory.map((bar) => ({
+      time: toChartTimestamp(bar.date),
+      open: Number(bar.open),
+      high: Number(bar.high),
+      low: Number(bar.low),
+      close: Number(bar.close),
     }));
 
     if (hasToday && today) {
       data.push({
-        time: Math.floor(Date.now() / 1000) as UTCTimestamp,
+        time: toChartTimestamp(new Date()),
         open: today.open as number,
         high: today.high as number,
         low: today.low as number,
         close: today.current as number,
       });
     }
+
     return data;
   }, [history, today]);
 
-  // Keep ref to candles for resize handler
-  const candlesRef = useRef(candles);
-  useEffect(() => {
-    candlesRef.current = candles;
-  }, [candles]);
-
   const markers = useMemo(() => {
-    if (!candles.length) return [];
+    if (!candles.length) return [] as SeriesMarker<Time>[];
 
     const minTime = candles[0].time as number;
     const maxTime = candles[candles.length - 1].time as number;
-    const m: Array<{ time: UTCTimestamp; position: 'belowBar' | 'aboveBar'; color: string; shape: 'arrowUp' | 'arrowDown'; text: string }> = [];
+    const output: SeriesMarker<Time>[] = [];
 
-    trades.forEach(t => {
-      const entryTime = Math.floor(new Date(t.entryDate).getTime() / 1000) as UTCTimestamp;
-      const exitTime = Math.floor(new Date(t.exitDate).getTime() / 1000) as UTCTimestamp;
+    trades.forEach((trade) => {
+      const entryTime = toChartTimestamp(trade.entryDate) as number;
+      const exitTime = toChartTimestamp(trade.exitDate) as number;
 
-      if ((entryTime as number) >= minTime && (entryTime as number) <= maxTime) {
-        m.push({ time: entryTime, position: 'belowBar', color: 'rgba(5,150,105,0.65)', shape: 'arrowUp', text: '' });
+      if (entryTime >= minTime && entryTime <= maxTime) {
+        output.push({
+          time: entryTime as UTCTimestamp,
+          position: 'belowBar',
+          color: 'rgba(5,150,105,0.65)',
+          shape: 'arrowUp',
+          text: '',
+        });
       }
-      if (t.exitReason !== 'end_of_data' && (exitTime as number) >= minTime && (exitTime as number) <= maxTime) {
-        m.push({ time: exitTime, position: 'aboveBar', color: 'rgba(239,68,68,0.75)', shape: 'arrowDown', text: '' });
+
+      if (trade.exitReason !== 'end_of_data' && exitTime >= minTime && exitTime <= maxTime) {
+        output.push({
+          time: exitTime as UTCTimestamp,
+          position: 'aboveBar',
+          color: 'rgba(239,68,68,0.75)',
+          shape: 'arrowDown',
+          text: '',
+        });
       }
     });
-    return m;
+
+    return output;
   }, [candles, trades]);
 
-  // 2. Theme Listener (Once)
   useEffect(() => {
     const onTheme = (e: Event) => {
-      const dark = !!((e as any)?.detail?.effectiveDark ?? document.documentElement.classList.contains('dark'));
+      const dark = !!((e as CustomEvent<{ effectiveDark?: boolean }>).detail?.effectiveDark ?? document.documentElement.classList.contains('dark'));
       setIsDark(dark);
     };
     window.addEventListener('themechange', onTheme);
     return () => window.removeEventListener('themechange', onTheme);
   }, []);
 
-  // 3. Chart Initialization (Once)
   useEffect(() => {
     if (!containerRef.current) return;
 
-    // Initial colors (will be updated by effect below immediately)
-    const bg = isDark ? '#0b1220' : '#ffffff';
-    const text = isDark ? '#e5e7eb' : '#374151';
-    const grid = isDark ? '#1f2937' : '#f5f5f5';
-    const border = isDark ? '#374151' : '#e5e7eb';
+    const darkNow = typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false;
+    const bg = darkNow ? '#0b1220' : '#ffffff';
+    const text = darkNow ? '#e5e7eb' : '#374151';
+    const grid = darkNow ? '#1f2937' : '#f5f5f5';
+    const border = darkNow ? '#374151' : '#e5e7eb';
 
     const chart = createChart(containerRef.current, {
+      autoSize: true,
       width: containerRef.current.clientWidth,
       height: containerRef.current.clientHeight || 140,
       layout: { background: { color: bg }, textColor: text },
       grid: { vertLines: { color: grid }, horzLines: { color: grid } },
       rightPriceScale: { borderColor: border },
-      timeScale: { borderColor: border, timeVisible: true, secondsVisible: false, rightOffset: 0, fixLeftEdge: true, barSpacing: 10 },
+      timeScale: {
+        borderColor: border,
+        timeVisible: true,
+        secondsVisible: false,
+        rightOffset: 0,
+        fixLeftEdge: true,
+        barSpacing: 10,
+      },
       crosshair: { mode: 0 },
       handleScroll: false,
       handleScale: false,
     });
     chartRef.current = chart;
 
-    const series = chart.addCandlestickSeries({
+    const series = chart.addSeries(CandlestickSeries, {
       upColor: '#10B981',
       downColor: '#EF4444',
       wickUpColor: '#10B981',
@@ -119,46 +152,33 @@ export function MiniQuoteChart({ history, today, trades, highIBS, isOpenPosition
       borderVisible: false,
     });
     seriesRef.current = series;
+    markersApiRef.current = createSeriesMarkers(series, []);
 
-    try { chart.priceScale('right').applyOptions({ scaleMargins: { top: 0.15, bottom: 0.15 } }); } catch { /* ignore */ }
-
-    const onResize = () => {
-      if (!containerRef.current || !chartRef.current) return;
-      const w = containerRef.current.clientWidth;
-      chartRef.current.applyOptions({ width: w, height: containerRef.current.clientHeight || 140 });
-
-      // Update bar spacing based on current candles length
-      try {
-        const currentCandles = candlesRef.current;
-        if (currentCandles.length) {
-            const spacing = Math.max(4, Math.min(24, Math.floor((w * 0.7) / currentCandles.length)));
-            chartRef.current.timeScale().applyOptions({ barSpacing: spacing });
-        }
-      } catch { /* ignore */ }
-    };
-
-    window.addEventListener('resize', onResize);
+    try {
+      chart.priceScale('right').applyOptions({
+        scaleMargins: { top: 0.15, bottom: 0.15 },
+      });
+    } catch {
+      // ignore
+    }
 
     return () => {
-      window.removeEventListener('resize', onResize);
+      markersApiRef.current = null;
       if (chartRef.current) {
         chartRef.current.remove();
         chartRef.current = null;
-        seriesRef.current = null;
-        targetLineRef.current = null;
-        entryLineRef.current = null;
       }
+      seriesRef.current = null;
+      targetLineRef.current = null;
+      entryLineRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Run only once
+  }, []);
 
-  // 4. Update Chart Data & Options (When candles or theme changes)
   useEffect(() => {
     const chart = chartRef.current;
     const series = seriesRef.current;
     if (!chart || !series || !containerRef.current) return;
 
-    // Update Theme Options
     const bg = isDark ? '#0b1220' : '#ffffff';
     const text = isDark ? '#e5e7eb' : '#374151';
     const grid = isDark ? '#1f2937' : '#f5f5f5';
@@ -171,33 +191,26 @@ export function MiniQuoteChart({ history, today, trades, highIBS, isOpenPosition
       timeScale: { borderColor: border },
     });
 
-    // Update Data
     if (candles.length > 0) {
-       series.setData(candles);
-
-       // Update TimeScale Spacing
-       const width = containerRef.current.clientWidth || 300;
-       const targetRatio = 0.7;
-       const spacing = Math.max(4, Math.min(24, Math.floor((width * targetRatio) / candles.length)));
-       const rightOffset = Math.max(1, Math.round(candles.length * 0.05));
-       try { chart.timeScale().applyOptions({ rightOffset, barSpacing: spacing }); } catch { /* ignore */ }
+      series.setData(candles);
+      const width = containerRef.current.clientWidth || 300;
+      const spacing = Math.max(4, Math.min(24, Math.floor((width * 0.7) / candles.length)));
+      const rightOffset = Math.max(1, Math.round(candles.length * 0.05));
+      chart.timeScale().applyOptions({ rightOffset, barSpacing: spacing });
     }
   }, [candles, isDark]);
 
-  // 5. Update Markers & Lines (When logic changes)
   useEffect(() => {
+    markersApiRef.current?.setMarkers(markers);
+
     const series = seriesRef.current;
     if (!series) return;
 
-    // Update Markers
-    series.setMarkers(markers);
-
-    // Update Price Lines
-    // Remove existing lines
     if (targetLineRef.current) {
       series.removePriceLine(targetLineRef.current);
       targetLineRef.current = null;
     }
+
     if (entryLineRef.current) {
       series.removePriceLine(entryLineRef.current);
       entryLineRef.current = null;
@@ -205,7 +218,6 @@ export function MiniQuoteChart({ history, today, trades, highIBS, isOpenPosition
 
     const hasToday = !!(today && today.low != null && today.high != null && today.open != null && today.current != null);
 
-    // Add Target Price Line
     if (isOpenPosition && hasToday && (today!.high as number) > (today!.low as number)) {
       const target = (today!.low as number) + highIBS * ((today!.high as number) - (today!.low as number));
       targetLineRef.current = series.createPriceLine({
@@ -214,11 +226,10 @@ export function MiniQuoteChart({ history, today, trades, highIBS, isOpenPosition
         lineWidth: 2,
         lineStyle: 0,
         axisLabelVisible: true,
-        title: 'Цель IBS'
+        title: 'Цель IBS',
       });
     }
 
-    // Add Entry Price Line
     if (isOpenPosition && typeof entryPrice === 'number') {
       entryLineRef.current = series.createPriceLine({
         price: entryPrice,
@@ -226,13 +237,10 @@ export function MiniQuoteChart({ history, today, trades, highIBS, isOpenPosition
         lineWidth: 1,
         lineStyle: 2,
         axisLabelVisible: true,
-        title: 'Вход'
+        title: 'Вход',
       });
     }
-
   }, [markers, isOpenPosition, highIBS, entryPrice, today]);
 
-  return (
-    <div ref={containerRef} className="w-full h-full min-h-[120px] overflow-hidden" />
-  );
+  return <div ref={containerRef} className="w-full h-full min-h-[120px] overflow-hidden" />;
 }

--- a/src/components/SingleTickerPage.tsx
+++ b/src/components/SingleTickerPage.tsx
@@ -430,10 +430,14 @@ export function SingleTickerPage() {
                 const now = new Date();
                 const ymd = ET_YMD_FMT
                   .formatToParts(now)
-                  .reduce((acc: any, p) => { if (p.type !== 'literal') acc[p.type] = p.value; return acc; }, {});
+                  .reduce<Record<string, string>>((acc, p) => {
+                    if (p.type !== 'literal') acc[p.type] = p.value;
+                    return acc;
+                  }, {});
                 const y = String(ymd.year);
                 const md = `${ymd.month}-${ymd.day}`;
-                const short = !!(tradingCalendar && tradingCalendar.shortDays && tradingCalendar.shortDays[y] && tradingCalendar.shortDays[y][md]);
+                const shortDays = tradingCalendar?.shortDays as Record<string, Record<string, boolean>> | undefined;
+                const short = !!shortDays?.[y]?.[md];
                 const start = parseHm(tradingCalendar?.tradingHours?.normal?.start) || { H: 9, M: 30 };
                 const endHm = short ? (parseHm(tradingCalendar?.tradingHours?.short?.end) || { H: 13, M: 0 }) : (parseHm(tradingCalendar?.tradingHours?.normal?.end) || { H: 16, M: 0 });
                 const fmt = (x: { H: number; M: number }) => `${String(x.H).padStart(2, '0')}:${String(x.M).padStart(2, '0')}`;

--- a/src/components/TradingChart.tsx
+++ b/src/components/TradingChart.tsx
@@ -1,24 +1,40 @@
-import { useEffect, useRef, useState, useMemo, memo } from 'react';
-import { createChart, type IChartApi, type ISeriesApi, type UTCTimestamp } from 'lightweight-charts';
+import { useEffect, useMemo, useRef, useState, memo } from 'react';
+import {
+  CandlestickSeries,
+  HistogramSeries,
+  LineSeries,
+  createChart,
+  createSeriesMarkers,
+  type IChartApi,
+  type ISeriesApi,
+  type ISeriesMarkersPluginApi,
+  type MouseEventParams,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
 import { formatOHLCYMD } from '../lib/utils';
 import { toChartTimestamp } from '../lib/date-utils';
 import type { OHLCData, Trade, SplitEvent } from '../types';
 import { useAppStore } from '../stores';
 import { logError } from '../lib/error-logger';
 
-// Функция для расчета EMA (вынесена из компонента для предотвращения пересоздания)
+const MIN_CHART_HEIGHT = 520;
+
+type RangeKey = 'ALL' | '1Y' | '6M' | '3M' | '1M';
+
 const calculateEMA = (data: OHLCData[], period: number): number[] => {
+  if (data.length < period) return [];
+
   const ema: number[] = [];
   const multiplier = 2 / (period + 1);
 
-  // Первое значение - это SMA
   let sum = 0;
-  for (let i = 0; i < Math.min(period, data.length); i++) {
+  for (let i = 0; i < period; i++) {
     sum += data[i].close;
   }
   ema[period - 1] = sum / period;
 
-  // Остальные значения - EMA
   for (let i = period; i < data.length; i++) {
     ema[i] = (data[i].close - ema[i - 1]) * multiplier + ema[i - 1];
   }
@@ -33,7 +49,6 @@ interface TradingChartProps {
 }
 
 export const TradingChart = memo(function TradingChart({ data, trades, splits = [] }: TradingChartProps) {
-  const MIN_CHART_HEIGHT = 520;
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const candlestickSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
@@ -41,480 +56,472 @@ export const TradingChart = memo(function TradingChart({ data, trades, splits = 
   const volumeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
   const ema20SeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const ema200SeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+  const markersApiRef = useRef<ISeriesMarkersPluginApi<Time> | null>(null);
+  const crosshairHandlerRef = useRef<((param: MouseEventParams<Time>) => void) | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
-  const unsubscribeRef = useRef<(() => void) | null>(null);
-  const resizeHandlerRef = useRef<(() => void) | null>(null);
 
   const [chartReady, setChartReady] = useState(false);
+  const [activeRange, setActiveRange] = useState<RangeKey>('ALL');
 
   const [showEMA20, setShowEMA20] = useState(false);
   const [showEMA200, setShowEMA200] = useState(false);
-  // По умолчанию оба скрыты
   const [showIBS, setShowIBS] = useState(false);
   const [showVolume, setShowVolume] = useState(false);
 
-  // Refs to track current state for callbacks without triggering re-renders
   const showIBSRef = useRef(showIBS);
   const showVolumeRef = useRef(showVolume);
 
-  const [isDark, setIsDark] = useState<boolean>(() => typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false);
-  const indicatorPanePercent = useAppStore(s => s.indicatorPanePercent);
+  const [isDark, setIsDark] = useState<boolean>(() =>
+    typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false
+  );
+  const indicatorPanePercent = useAppStore((s) => s.indicatorPanePercent);
 
-  // Update refs when state changes
   useEffect(() => {
     showIBSRef.current = showIBS;
     showVolumeRef.current = showVolume;
   }, [showIBS, showVolume]);
 
-  // Handle theme changes
   useEffect(() => {
-    const onTheme = (e: any) => {
-      const dark = !!(e?.detail?.effectiveDark ?? document.documentElement.classList.contains('dark'));
+    const onTheme = (e: Event) => {
+      const dark = !!((e as CustomEvent<{ effectiveDark?: boolean }>).detail?.effectiveDark ?? document.documentElement.classList.contains('dark'));
       setIsDark(dark);
     };
-    window.addEventListener('themechange' as any, onTheme as any);
-    return () => {
-      window.removeEventListener('themechange' as any, onTheme as any);
-    };
+    window.addEventListener('themechange', onTheme);
+    return () => window.removeEventListener('themechange', onTheme);
   }, []);
 
-  // 1. Initialize Chart (only when container is available and theme changes)
   useEffect(() => {
     if (!chartContainerRef.current) return;
 
-    // Destroy existing chart if any (e.g. theme change)
-    if (chartRef.current) {
-        if (unsubscribeRef.current) unsubscribeRef.current();
-        if (resizeHandlerRef.current) window.removeEventListener('resize', resizeHandlerRef.current);
-        chartRef.current.remove();
-        chartRef.current = null;
+    const el = chartContainerRef.current;
+    const darkNow = typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false;
+    const bg = darkNow ? '#0b1220' : '#ffffff';
+    const text = darkNow ? '#e5e7eb' : '#1f2937';
+    const grid = darkNow ? '#1f2937' : '#eef2ff';
+    const border = darkNow ? '#374151' : '#e5e7eb';
 
-        // IMPORTANT: Clear series refs to avoid using disposed series
-        candlestickSeriesRef.current = null;
-        ibsSeriesRef.current = null;
-        volumeSeriesRef.current = null;
-        ema20SeriesRef.current = null;
-        ema200SeriesRef.current = null;
+    const chart = createChart(el, {
+      autoSize: true,
+      width: el.clientWidth,
+      height: Math.max(el.clientHeight || 0, MIN_CHART_HEIGHT),
+      layout: { background: { color: bg }, textColor: text },
+      grid: { vertLines: { color: grid }, horzLines: { color: grid } },
+      crosshair: { mode: 1 },
+      rightPriceScale: { borderColor: border },
+      timeScale: { borderColor: border, timeVisible: true, secondsVisible: false, rightOffset: 8 },
+    });
 
-        setChartReady(false);
+    chartRef.current = chart;
+
+    const candlestickSeries = chart.addSeries(CandlestickSeries, {
+      upColor: '#10B981',
+      downColor: '#EF4444',
+      borderUpColor: '#10B981',
+      borderDownColor: '#EF4444',
+      wickUpColor: '#10B981',
+      wickDownColor: '#EF4444',
+      borderVisible: true,
+    });
+    candlestickSeriesRef.current = candlestickSeries;
+
+    const volumeSeries = chart.addSeries(HistogramSeries, {
+      color: darkNow ? 'rgba(148, 163, 184, 0.35)' : 'rgba(148, 163, 184, 0.45)',
+      priceFormat: { type: 'volume' },
+      priceScaleId: '',
+      base: 0,
+      visible: false,
+      title: 'Объём',
+    });
+    volumeSeriesRef.current = volumeSeries;
+
+    const ibsHist = chart.addSeries(HistogramSeries, {
+      priceScaleId: '',
+      base: 0,
+      priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
+      visible: false,
+      title: 'IBS',
+    });
+    ibsSeriesRef.current = ibsHist;
+
+    const ema20Series = chart.addSeries(LineSeries, {
+      color: darkNow ? '#60a5fa' : '#2196F3',
+      lineWidth: 2,
+      title: 'EMA 20',
+      visible: false,
+    });
+    ema20SeriesRef.current = ema20Series;
+
+    const ema200Series = chart.addSeries(LineSeries, {
+      color: darkNow ? '#fbbf24' : '#FF9800',
+      lineWidth: 2,
+      title: 'EMA 200',
+      visible: false,
+    });
+    ema200SeriesRef.current = ema200Series;
+
+    markersApiRef.current = createSeriesMarkers(candlestickSeries, []);
+
+    const tooltipEl = document.createElement('div');
+    tooltipEl.style.position = 'absolute';
+    tooltipEl.style.left = '12px';
+    tooltipEl.style.top = '8px';
+    tooltipEl.style.zIndex = '10';
+    tooltipEl.style.pointerEvents = 'none';
+    tooltipEl.style.background = darkNow ? 'rgba(31,41,55,0.75)' : 'rgba(17,24,39,0.7)';
+    tooltipEl.style.color = 'white';
+    tooltipEl.style.padding = '6px 8px';
+    tooltipEl.style.borderRadius = '6px';
+    tooltipEl.style.fontSize = '12px';
+    tooltipEl.style.backdropFilter = 'blur(4px)';
+    tooltipEl.style.display = 'none';
+    el.appendChild(tooltipEl);
+    tooltipRef.current = tooltipEl;
+
+    const crosshairHandler = (param: MouseEventParams<Time>) => {
+      if (!tooltipRef.current || !param.time || !param.seriesData) {
         if (tooltipRef.current) tooltipRef.current.style.display = 'none';
-    }
-
-    try {
-      // Theme colors
-      const bg = isDark ? '#0b1220' : '#ffffff';
-      const text = isDark ? '#e5e7eb' : '#1f2937';
-      const grid = isDark ? '#1f2937' : '#eef2ff';
-      const border = isDark ? '#374151' : '#e5e7eb';
-
-      const el = chartContainerRef.current;
-      const totalH = Math.max(el.clientHeight || 0, MIN_CHART_HEIGHT);
-      const chart = createChart(el, {
-        width: el.clientWidth,
-        height: totalH,
-        layout: { background: { color: bg }, textColor: text },
-        grid: { vertLines: { color: grid }, horzLines: { color: grid } },
-        crosshair: { mode: 1 },
-        rightPriceScale: { borderColor: border },
-        timeScale: { borderColor: border, timeVisible: true, secondsVisible: false, rightOffset: 8 },
-      });
-
-      chartRef.current = chart;
-
-      // Add Series
-      const candlestickSeries = chart.addCandlestickSeries({
-        upColor: '#10B981',
-        downColor: '#EF4444',
-        borderUpColor: '#10B981',
-        borderDownColor: '#EF4444',
-        wickUpColor: '#10B981',
-        wickDownColor: '#EF4444',
-        borderVisible: true,
-      });
-      candlestickSeriesRef.current = candlestickSeries;
-
-      const volumeSeries = chart.addHistogramSeries({
-        color: isDark ? 'rgba(148, 163, 184, 0.35)' : 'rgba(148, 163, 184, 0.45)',
-        priceFormat: { type: 'volume' as const },
-        priceScaleId: '',
-        base: 0,
-        visible: false,
-        title: 'Объём',
-      });
-      volumeSeriesRef.current = volumeSeries;
-
-      const ibsHist = chart.addHistogramSeries({
-        priceScaleId: '',
-        base: 0,
-        priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
-        visible: false,
-        title: 'IBS',
-      });
-      ibsSeriesRef.current = ibsHist;
-
-      const ema20Series = chart.addLineSeries({
-        color: isDark ? '#60a5fa' : '#2196F3',
-        lineWidth: 2,
-        title: 'EMA 20',
-        visible: false,
-      });
-      ema20SeriesRef.current = ema20Series;
-
-      const ema200Series = chart.addLineSeries({
-        color: isDark ? '#fbbf24' : '#FF9800',
-        lineWidth: 2,
-        title: 'EMA 200',
-        visible: false,
-      });
-      ema200SeriesRef.current = ema200Series;
-
-      // Tooltip
-      if (!tooltipRef.current) {
-          const tooltipEl = document.createElement('div');
-          tooltipEl.style.position = 'absolute';
-          tooltipEl.style.left = '12px';
-          tooltipEl.style.top = '8px';
-          tooltipEl.style.zIndex = '10';
-          tooltipEl.style.pointerEvents = 'none';
-          tooltipEl.style.background = isDark ? 'rgba(31,41,55,0.75)' : 'rgba(17,24,39,0.7)';
-          tooltipEl.style.color = 'white';
-          tooltipEl.style.padding = '6px 8px';
-          tooltipEl.style.borderRadius = '6px';
-          tooltipEl.style.fontSize = '12px';
-          tooltipEl.style.backdropFilter = 'blur(4px)';
-          tooltipEl.style.display = 'none';
-          el.appendChild(tooltipEl);
-          tooltipRef.current = tooltipEl;
-      } else {
-        // Update tooltip style for theme
-        tooltipRef.current.style.background = isDark ? 'rgba(31,41,55,0.75)' : 'rgba(17,24,39,0.7)';
+        return;
       }
 
-      const crosshairHandler = (param: any) => {
-        if (!tooltipRef.current || !param || !param.time) {
-          if (tooltipRef.current) tooltipRef.current.style.display = 'none';
-          return;
-        }
-        const paramWithData = param as { seriesPrices?: Map<unknown, unknown>; seriesData?: Map<unknown, unknown> };
-        const priceMap = paramWithData.seriesPrices;
-        const seriesData = paramWithData.seriesData;
-        if (!priceMap || !seriesData) {
-          tooltipRef.current.style.display = 'none';
-          return;
-        }
-        const price = priceMap.get(candlestickSeries as unknown as object);
-        if (!price) {
-          tooltipRef.current.style.display = 'none';
-          return;
-        }
-        const bar = seriesData.get(candlestickSeries as unknown as object) as { open?: number; high?: number; low?: number; close?: number } | undefined;
+      const candleData = param.seriesData.get(candlestickSeries) as { open?: number; high?: number; low?: number; close?: number } | undefined;
+      if (!candleData) {
+        tooltipRef.current.style.display = 'none';
+        return;
+      }
 
+      const vol = showVolumeRef.current ? (param.seriesData.get(volumeSeries) as { value?: number } | undefined)?.value : undefined;
+      const ibsVal = showIBSRef.current ? (param.seriesData.get(ibsHist) as { value?: number } | undefined)?.value : undefined;
 
-        const vol = (showVolumeRef.current && volumeSeries) ? (seriesData.get(volumeSeries as any) as { value?: number } | undefined)?.value : undefined;
+      const o = candleData.open;
+      const h = candleData.high;
+      const l = candleData.low;
+      const c = candleData.close;
+      const pct = typeof o === 'number' && typeof c === 'number' && o !== 0 ? ((c - o) / o) * 100 : null;
+      const ibsStr = typeof ibsVal === 'number' ? ` · IBS ${(ibsVal * 100).toFixed(0)}%` : '';
+      const volStr = typeof vol === 'number' ? ` · Объём ${vol.toLocaleString()}` : '';
+      const pctStr = typeof pct === 'number' ? ` · ${pct.toFixed(2)}%` : '';
 
-        const ibsVal = (showIBSRef.current && ibsHist) ? (seriesData.get(ibsHist as any) as { value?: number } | undefined)?.value : undefined;
+      tooltipRef.current.textContent = `О ${o?.toFixed?.(2) ?? '-'} В ${h?.toFixed?.(2) ?? '-'} Н ${l?.toFixed?.(2) ?? '-'} З ${c?.toFixed?.(2) ?? '-'}${pctStr}${ibsStr}${volStr}`;
+      tooltipRef.current.style.display = 'block';
+    };
 
-        const o = bar?.open, h = bar?.high, l = bar?.low, c = bar?.close;
-        const pct = o ? (((c! - o) / o) * 100) : 0;
-        const ibsStr = (typeof ibsVal === 'number') ? ` · IBS ${(ibsVal * 100).toFixed(0)}%` : '';
-        tooltipRef.current.textContent = `О ${o?.toFixed?.(2) ?? '-'} В ${h?.toFixed?.(2) ?? '-'} Н ${l?.toFixed?.(2) ?? '-'} З ${c?.toFixed?.(2) ?? '-'} · ${pct ? pct.toFixed(2) + '%' : ''}${ibsStr}${vol ? ' · Объём ' + vol.toLocaleString() : ''}`;
-        tooltipRef.current.style.display = 'block';
-      };
+    crosshairHandlerRef.current = crosshairHandler;
+    chart.subscribeCrosshairMove(crosshairHandler);
 
-      unsubscribeRef.current = chart.subscribeCrosshairMove(crosshairHandler);
-
-      // Resize Handler
-      const handleResize = () => {
-        if (!chartContainerRef.current || !chartRef.current) return;
-        try {
-          const w = chartContainerRef.current.clientWidth;
-          const total = Math.max(chartContainerRef.current.clientHeight || 0, MIN_CHART_HEIGHT);
-
-          if (chartRef.current && typeof (chartRef.current as any).applyOptions === 'function') {
-             (chartRef.current as any).applyOptions({ width: w, height: total });
-          }
-        } catch {
-           // ignore
-        }
-      };
-      resizeHandlerRef.current = handleResize;
-      window.addEventListener('resize', handleResize);
-
-      setChartReady(true);
-
-    } catch (error) {
-      console.error('Error creating chart', error);
-    }
+    setChartReady(true);
 
     return () => {
-      if (unsubscribeRef.current) { unsubscribeRef.current(); unsubscribeRef.current = null; }
-      if (resizeHandlerRef.current) { window.removeEventListener('resize', resizeHandlerRef.current); resizeHandlerRef.current = null; }
-
-      if (chartRef.current) {
-          chartRef.current.remove();
-          chartRef.current = null;
+      if (crosshairHandlerRef.current && chartRef.current) {
+        try {
+          chartRef.current.unsubscribeCrosshairMove(crosshairHandlerRef.current);
+        } catch {
+          // ignore
+        }
       }
+      crosshairHandlerRef.current = null;
+      markersApiRef.current = null;
 
-      // Cleanup series refs on unmount
+      if (tooltipRef.current && tooltipRef.current.parentElement) {
+        try {
+          tooltipRef.current.parentElement.removeChild(tooltipRef.current);
+        } catch {
+          // ignore
+        }
+      }
+      tooltipRef.current = null;
+
       candlestickSeriesRef.current = null;
       ibsSeriesRef.current = null;
       volumeSeriesRef.current = null;
       ema20SeriesRef.current = null;
       ema200SeriesRef.current = null;
 
-      if (tooltipRef.current && tooltipRef.current.parentElement) {
-        try {
-          tooltipRef.current.parentElement.removeChild(tooltipRef.current);
-        } catch { /* ignore */ }
-        tooltipRef.current = null;
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
       }
+
+      setChartReady(false);
     };
-  }, [isDark]); // Recreate chart only on theme change
+  }, []);
 
-  // Pre-calculate timestamps (Optimization: reduces parsing by 5x)
-  const times = useMemo(() => {
-    return data.map(d => {
-        try {
-            return toChartTimestamp(d.date);
-        } catch {
-            return 0 as UTCTimestamp;
-        }
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    const bg = isDark ? '#0b1220' : '#ffffff';
+    const text = isDark ? '#e5e7eb' : '#1f2937';
+    const grid = isDark ? '#1f2937' : '#eef2ff';
+    const border = isDark ? '#374151' : '#e5e7eb';
+
+    chartRef.current.applyOptions({
+      layout: { background: { color: bg }, textColor: text },
+      grid: { vertLines: { color: grid }, horzLines: { color: grid } },
+      rightPriceScale: { borderColor: border },
+      timeScale: { borderColor: border },
     });
-  }, [data]);
 
-  // Memoize data preparations to avoid recalculation on theme change or re-renders
+    if (tooltipRef.current) {
+      tooltipRef.current.style.background = isDark ? 'rgba(31,41,55,0.75)' : 'rgba(17,24,39,0.7)';
+    }
+
+    ema20SeriesRef.current?.applyOptions({ color: isDark ? '#60a5fa' : '#2196F3' });
+    ema200SeriesRef.current?.applyOptions({ color: isDark ? '#fbbf24' : '#FF9800' });
+    volumeSeriesRef.current?.applyOptions({ color: isDark ? 'rgba(148, 163, 184, 0.35)' : 'rgba(148, 163, 184, 0.45)' });
+  }, [isDark]);
+
+  const times = useMemo(
+    () =>
+      data.map((d) => {
+        try {
+          return toChartTimestamp(d.date);
+        } catch {
+          return 0 as UTCTimestamp;
+        }
+      }),
+    [data]
+  );
+
   const chartData = useMemo(() => {
     if (!data.length) return [];
-    return data.map((bar, i) => {
+    return data
+      .map((bar, i) => {
         const t = times[i];
-        if (t === 0) return { time: 0 as UTCTimestamp, open: 0, high: 0, low: 0, close: 0 };
+        if (t === 0) return null;
         return {
-            time: t,
-            open: Number(bar.open),
-            high: Number(bar.high),
-            low: Number(bar.low),
-            close: Number(bar.close)
+          time: t,
+          open: Number(bar.open),
+          high: Number(bar.high),
+          low: Number(bar.low),
+          close: Number(bar.close),
         };
-    });
+      })
+      .filter((point): point is { time: UTCTimestamp; open: number; high: number; low: number; close: number } => point !== null);
   }, [data, times]);
 
   const ema20Values = useMemo(() => calculateEMA(data, 20), [data]);
-  const ema20Data = useMemo(() => {
-    if (!data.length) return [];
-    return data.map((_, index) => {
-        const v = ema20Values[index];
-        if (typeof v !== 'number' || !Number.isFinite(v)) return null;
-        return { time: times[index], value: v };
-    }).filter((p): p is {time: UTCTimestamp, value: number} => p !== null && p.time !== 0);
-  }, [data, ema20Values, times]);
+  const ema20Data = useMemo(
+    () =>
+      data
+        .map((_, index) => {
+          const v = ema20Values[index];
+          const t = times[index];
+          if (typeof v !== 'number' || !Number.isFinite(v) || t === 0) return null;
+          return { time: t, value: v };
+        })
+        .filter((p): p is { time: UTCTimestamp; value: number } => p !== null),
+    [data, ema20Values, times]
+  );
 
   const ema200Values = useMemo(() => calculateEMA(data, 200), [data]);
-  const ema200Data = useMemo(() => {
-    if (!data.length) return [];
-    return data.map((_, index) => {
-        const v = ema200Values[index];
-        if (typeof v !== 'number' || !Number.isFinite(v)) return null;
-        return { time: times[index], value: v };
-    }).filter((p): p is {time: UTCTimestamp, value: number} => p !== null && p.time !== 0);
-  }, [data, ema200Values, times]);
+  const ema200Data = useMemo(
+    () =>
+      data
+        .map((_, index) => {
+          const v = ema200Values[index];
+          const t = times[index];
+          if (typeof v !== 'number' || !Number.isFinite(v) || t === 0) return null;
+          return { time: t, value: v };
+        })
+        .filter((p): p is { time: UTCTimestamp; value: number } => p !== null),
+    [data, ema200Values, times]
+  );
 
-  const volumeData = useMemo(() => {
-    if (!data.length) return [];
-    return data.map((bar, i) => ({
-        time: times[i],
-        value: Number(bar.volume),
-        color: bar.close >= bar.open ? (isDark ? 'rgba(16, 185, 129, 0.45)' : 'rgba(16, 185, 129, 0.6)') : (isDark ? 'rgba(239, 68, 68, 0.45)' : 'rgba(239, 68, 68, 0.6)')
-    }));
-  }, [data, isDark, times]);
+  const volumeData = useMemo(
+    () =>
+      data
+        .map((bar, i) => {
+          const t = times[i];
+          if (t === 0) return null;
+          return {
+            time: t,
+            value: Number(bar.volume),
+            color:
+              bar.close >= bar.open
+                ? isDark
+                  ? 'rgba(16, 185, 129, 0.45)'
+                  : 'rgba(16, 185, 129, 0.6)'
+                : isDark
+                  ? 'rgba(239, 68, 68, 0.45)'
+                  : 'rgba(239, 68, 68, 0.6)',
+          };
+        })
+        .filter((point): point is { time: UTCTimestamp; value: number; color: string } => point !== null),
+    [data, isDark, times]
+  );
 
-  const ibsData = useMemo(() => {
-     if (!data.length) return [];
-     return data.map((bar, i) => {
-        const range = Math.max(1e-9, bar.high - bar.low);
-        const ibs = (bar.close - bar.low) / range;
-        const color = ibs <= 0.10
-            ? (isDark ? 'rgba(5,150,105,1)' : 'rgba(5,150,105,1)')
-            : (ibs >= 0.75 ? (isDark ? 'rgba(239,68,68,0.9)' : 'rgba(239,68,68,0.9)') : (isDark ? 'rgba(156,163,175,0.5)' : 'rgba(107,114,128,0.5)'));
-        return { time: times[i], value: ibs, color };
-     });
-  }, [data, isDark, times]);
+  const ibsData = useMemo(
+    () =>
+      data
+        .map((bar, i) => {
+          const t = times[i];
+          if (t === 0) return null;
 
-  // 2. Update Data
-  useEffect(() => {
-    if (!chartReady || !data.length || !candlestickSeriesRef.current) return;
+          const range = Math.max(1e-9, bar.high - bar.low);
+          const ibs = (bar.close - bar.low) / range;
+          const color =
+            ibs <= 0.1
+              ? 'rgba(5,150,105,1)'
+              : ibs >= 0.75
+                ? 'rgba(239,68,68,0.9)'
+                : isDark
+                  ? 'rgba(156,163,175,0.5)'
+                  : 'rgba(107,114,128,0.5)';
 
-    try {
-        if (candlestickSeriesRef.current) candlestickSeriesRef.current.setData(chartData);
+          return { time: t, value: ibs, color };
+        })
+        .filter((point): point is { time: UTCTimestamp; value: number; color: string } => point !== null),
+    [data, isDark, times]
+  );
 
-        // Initial time scale
-
-        try { if (chartRef.current?.timeScale) (chartRef.current.timeScale() as any).applyOptions({ rightOffset: 8 }); } catch { /* ignore */ }
-
-        if (volumeSeriesRef.current) {
-            volumeSeriesRef.current.setData(volumeData);
-        }
-
-        if (ibsSeriesRef.current) {
-             ibsSeriesRef.current.setData(ibsData);
-        }
-
-        if (ema20SeriesRef.current) {
-            ema20SeriesRef.current.setData(ema20Data);
-        }
-
-        if (ema200SeriesRef.current) {
-            ema200SeriesRef.current.setData(ema200Data);
-        }
-
-    } catch (e) {
-        logError('chart', 'Error updating chart data', { error: (e as Error).message }, 'TradingChart.updateData');
-    }
-
-  }, [chartReady, data.length, chartData, volumeData, ibsData, ema20Data, ema200Data]);
-
-  // 3. Update Markers
   useEffect(() => {
     if (!chartReady || !candlestickSeriesRef.current) return;
 
-    const allMarkers: Array<{ time: UTCTimestamp; position: 'belowBar' | 'aboveBar'; color: string; shape: 'arrowUp' | 'arrowDown' | 'circle'; text: string }> = [];
-      if (trades.length > 0) {
-        allMarkers.push(
-          ...trades.flatMap(trade => {
-            const markers: Array<{ time: UTCTimestamp; position: 'belowBar' | 'aboveBar'; color: string; shape: 'arrowUp' | 'arrowDown' | 'circle'; text: string }> = [
-              {
-                time: toChartTimestamp(trade.entryDate),
-                position: 'belowBar' as const,
-                color: '#2196F3',
-                shape: 'arrowUp' as const,
-                text: '',
-              },
-            ];
-            if (trade.exitReason !== 'end_of_data') {
-              markers.push({
-                time: toChartTimestamp(trade.exitDate),
-                position: 'aboveBar' as const,
-                color: '#2196F3',
-                shape: 'arrowDown' as const,
-                text: '',
-              });
-            }
-            return markers;
-          })
-        );
-      }
-      if (splits.length > 0) {
-        const ymdToTime = new Map<string, number>();
-        for (const bar of data) {
-          const ymd = formatOHLCYMD(bar.date);
-          if (!ymdToTime.has(ymd)) ymdToTime.set(ymd, toChartTimestamp(bar.date));
-        }
-        const splitMarkers = splits.map(s => {
-          const ymd = typeof s.date === 'string' ? s.date.slice(0, 10) : formatOHLCYMD(s.date);
-          const t = ymdToTime.get(ymd) ?? toChartTimestamp(ymd);
-          return {
-            time: t as UTCTimestamp,
-            position: 'belowBar' as const,
-            color: '#9C27B0',
-            shape: 'circle' as const,
-            text: 'S',
-          };
-        });
-        allMarkers.push(...splitMarkers);
-      }
-      try {
-        if (candlestickSeriesRef.current && typeof candlestickSeriesRef.current.setMarkers === 'function') {
-           candlestickSeriesRef.current.setMarkers(allMarkers);
-        }
-      } catch { /* ignore */ }
-  }, [chartReady, trades, splits, data]); // Data needed for split date matching? Yes.
+    try {
+      candlestickSeriesRef.current.setData(chartData);
+      volumeSeriesRef.current?.setData(volumeData);
+      ibsSeriesRef.current?.setData(ibsData);
+      ema20SeriesRef.current?.setData(ema20Data);
+      ema200SeriesRef.current?.setData(ema200Data);
+    } catch (e) {
+      logError('chart', 'Error updating chart data', { error: (e as Error).message }, 'TradingChart.updateData');
+    }
+  }, [chartReady, chartData, volumeData, ibsData, ema20Data, ema200Data]);
 
-  // 4. Update Layout
+  useEffect(() => {
+    if (!chartReady || !markersApiRef.current) return;
+
+    const allMarkers: SeriesMarker<Time>[] = [];
+
+    if (trades.length > 0) {
+      allMarkers.push(
+        ...trades.flatMap((trade) => {
+          const markers: SeriesMarker<Time>[] = [
+            {
+              time: toChartTimestamp(trade.entryDate),
+              position: 'belowBar',
+              color: '#2196F3',
+              shape: 'arrowUp',
+              text: '',
+            },
+          ];
+
+          if (trade.exitReason !== 'end_of_data') {
+            markers.push({
+              time: toChartTimestamp(trade.exitDate),
+              position: 'aboveBar',
+              color: '#2196F3',
+              shape: 'arrowDown',
+              text: '',
+            });
+          }
+
+          return markers;
+        })
+      );
+    }
+
+    if (splits.length > 0) {
+      const ymdToTime = new Map<string, UTCTimestamp>();
+      for (const bar of data) {
+        const ymd = formatOHLCYMD(bar.date);
+        if (!ymdToTime.has(ymd)) ymdToTime.set(ymd, toChartTimestamp(bar.date));
+      }
+
+      const splitMarkers: SeriesMarker<Time>[] = splits.map((split) => {
+        const ymd = typeof split.date === 'string' ? split.date.slice(0, 10) : formatOHLCYMD(split.date);
+        return {
+          time: ymdToTime.get(ymd) ?? toChartTimestamp(ymd),
+          position: 'belowBar',
+          color: '#9C27B0',
+          shape: 'circle',
+          text: 'S',
+        };
+      });
+
+      allMarkers.push(...splitMarkers);
+    }
+
+    markersApiRef.current.setMarkers(allMarkers);
+  }, [chartReady, trades, splits, data]);
+
   useEffect(() => {
     if (!candlestickSeriesRef.current) return;
 
     const indicatorFraction = Math.max(0.05, Math.min(0.4, indicatorPanePercent / 100));
     const priceBottomMargin = indicatorFraction + 0.1;
-    const volumeTopMargin = 1 - indicatorFraction;
+    const indicatorTopMargin = 1 - indicatorFraction;
 
-    try {
+    candlestickSeriesRef.current.priceScale().applyOptions({
+      scaleMargins: {
+        top: 0.1,
+        bottom: priceBottomMargin,
+      },
+    });
 
-      const candlePriceScale = candlestickSeriesRef.current.priceScale() as any;
-      if (candlePriceScale && typeof candlePriceScale.applyOptions === 'function') {
-        candlePriceScale.applyOptions({
-          scaleMargins: {
-            top: 0.1,
-            bottom: priceBottomMargin,
-          },
-        });
-      }
+    volumeSeriesRef.current?.priceScale().applyOptions({
+      scaleMargins: {
+        top: indicatorTopMargin,
+        bottom: 0,
+      },
+    });
 
-      if (volumeSeriesRef.current) {
-
-        const volPriceScale = volumeSeriesRef.current.priceScale() as any;
-        if (volPriceScale && typeof volPriceScale.applyOptions === 'function') {
-          volPriceScale.applyOptions({
-            scaleMargins: {
-              top: volumeTopMargin,
-              bottom: 0,
-            },
-          });
-        }
-      }
-
-      if (ibsSeriesRef.current) {
-
-        const ibsPriceScale = ibsSeriesRef.current.priceScale() as any;
-        if (ibsPriceScale && typeof ibsPriceScale.applyOptions === 'function') {
-          ibsPriceScale.applyOptions({
-            scaleMargins: {
-              top: volumeTopMargin,
-              bottom: 0,
-            },
-          });
-        }
-      }
-    } catch {
-      // ignore
-    }
+    ibsSeriesRef.current?.priceScale().applyOptions({
+      scaleMargins: {
+        top: indicatorTopMargin,
+        bottom: 0,
+      },
+    });
   }, [indicatorPanePercent, chartReady]);
 
-  // 5. Update Visibility
   useEffect(() => {
-    // Взаимоисключаемые индикаторы
-    if (showIBS && showVolume) setShowVolume(false);
-  }, [showIBS, showVolume]);
-
-  useEffect(() => {
-
-    const sIBS = ibsSeriesRef.current as any;
-    if (sIBS && typeof sIBS.applyOptions === 'function') {
-      try { sIBS.applyOptions({ visible: showIBS }); } catch { /* ignore */ }
-    }
-
-
-    const sVol = volumeSeriesRef.current as any;
-    if (sVol && typeof sVol.applyOptions === 'function') {
-      try { sVol.applyOptions({ visible: showVolume }); } catch { /* ignore */ }
-    }
-
-
-    const sEma20 = ema20SeriesRef.current as any;
-    if (sEma20 && typeof sEma20.applyOptions === 'function') {
-      try { sEma20.applyOptions({ visible: showEMA20 }); } catch { /* ignore */ }
-    }
-
-
-    const sEma200 = ema200SeriesRef.current as any;
-    if (sEma200 && typeof sEma200.applyOptions === 'function') {
-      try { sEma200.applyOptions({ visible: showEMA200 }); } catch { /* ignore */ }
-    }
+    ibsSeriesRef.current?.applyOptions({ visible: showIBS });
+    volumeSeriesRef.current?.applyOptions({ visible: showVolume });
+    ema20SeriesRef.current?.applyOptions({ visible: showEMA20 });
+    ema200SeriesRef.current?.applyOptions({ visible: showEMA200 });
   }, [showIBS, showVolume, showEMA20, showEMA200, chartReady]);
 
+  useEffect(() => {
+    if (!chartRef.current || !chartData.length) return;
+
+    const rightEdge = chartData[chartData.length - 1].time as number;
+    const leftEdge = chartData[0].time as number;
+
+    if (activeRange === 'ALL') {
+      chartRef.current.timeScale().fitContent();
+      return;
+    }
+
+    const daysByRange: Record<Exclude<RangeKey, 'ALL'>, number> = {
+      '1Y': 365,
+      '6M': 180,
+      '3M': 90,
+      '1M': 30,
+    };
+
+    const days = daysByRange[activeRange];
+    const from = Math.max(leftEdge, rightEdge - days * 24 * 60 * 60);
+
+    chartRef.current.timeScale().setVisibleRange({
+      from: from as UTCTimestamp,
+      to: rightEdge as UTCTimestamp,
+    });
+  }, [activeRange, chartData]);
 
   return (
     <div className="w-full grid grid-rows-[auto,1fr] gap-4 relative">
-      {/* Controls */}
       <div className="flex gap-2 flex-wrap">
+        {(['1M', '3M', '6M', '1Y', 'ALL'] as RangeKey[]).map((range) => (
+          <button
+            key={range}
+            onClick={() => setActiveRange(range)}
+            className={`px-3 py-1 text-sm rounded ${activeRange === range
+              ? 'bg-indigo-600 text-white'
+              : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+              }`}
+          >
+            {range}
+          </button>
+        ))}
         <button
           onClick={() => setShowEMA20(!showEMA20)}
           className={`px-3 py-1 text-sm rounded ${showEMA20
@@ -534,7 +541,7 @@ export const TradingChart = memo(function TradingChart({ data, trades, splits = 
           EMA 200
         </button>
         <button
-          onClick={() => { const next = !showIBS; setShowIBS(next); if (next) setShowVolume(false); }}
+          onClick={() => setShowIBS(!showIBS)}
           className={`px-3 py-1 text-sm rounded ${showIBS
             ? 'bg-gray-700 text-white'
             : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
@@ -545,7 +552,7 @@ export const TradingChart = memo(function TradingChart({ data, trades, splits = 
           IBS
         </button>
         <button
-          onClick={() => { const next = !showVolume; setShowVolume(next); if (next) setShowIBS(false); }}
+          onClick={() => setShowVolume(!showVolume)}
           className={`px-3 py-1 text-sm rounded ${showVolume
             ? 'bg-gray-500 text-white'
             : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
@@ -557,14 +564,13 @@ export const TradingChart = memo(function TradingChart({ data, trades, splits = 
         </button>
       </div>
 
-      {/* Single Chart Container */}
       <div className="relative w-full h-full min-h-0">
-         <div ref={chartContainerRef} className="w-full h-full overflow-hidden" />
-         {!data.length && (
-            <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-gray-900 z-10 text-gray-500">
-               Нет данных для графика
-            </div>
-         )}
+        <div ref={chartContainerRef} className="w-full h-full overflow-hidden" />
+        {!data.length && (
+          <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-gray-900 z-10 text-gray-500">
+            Нет данных для графика
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/__tests__/MiniQuoteChart.test.tsx
+++ b/src/components/__tests__/MiniQuoteChart.test.tsx
@@ -1,19 +1,22 @@
 import { render } from '@testing-library/react';
 import { MiniQuoteChart } from '../MiniQuoteChart';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { createChart } from 'lightweight-charts';
+import { CandlestickSeries, createChart } from 'lightweight-charts';
 
 // Mock lightweight-charts
 const mockSeries = {
   setData: vi.fn(),
   applyOptions: vi.fn(),
-  setMarkers: vi.fn(),
   createPriceLine: vi.fn().mockReturnValue({}), // Return dummy object for price line
   removePriceLine: vi.fn(),
 };
 
+const mockMarkersApi = {
+  setMarkers: vi.fn(),
+};
+
 const mockChart = {
-  addCandlestickSeries: vi.fn().mockReturnValue(mockSeries),
+  addSeries: vi.fn().mockReturnValue(mockSeries),
   priceScale: vi.fn().mockReturnValue({ applyOptions: vi.fn() }),
   timeScale: vi.fn().mockReturnValue({ applyOptions: vi.fn() }),
   applyOptions: vi.fn(),
@@ -21,7 +24,9 @@ const mockChart = {
 };
 
 vi.mock('lightweight-charts', () => ({
+  CandlestickSeries: Symbol('CandlestickSeries'),
   createChart: vi.fn(() => mockChart),
+  createSeriesMarkers: vi.fn(() => mockMarkersApi),
 }));
 
 describe('MiniQuoteChart Optimization', () => {
@@ -46,7 +51,8 @@ describe('MiniQuoteChart Optimization', () => {
     render(<MiniQuoteChart {...props} />);
 
     expect(createChart).toHaveBeenCalledTimes(1);
-    expect(mockChart.addCandlestickSeries).toHaveBeenCalledTimes(1);
+    expect(mockChart.addSeries).toHaveBeenCalledTimes(1);
+    expect(mockChart.addSeries).toHaveBeenCalledWith(CandlestickSeries, expect.any(Object));
   });
 
   it('should NOT recreate chart when props change (optimization check)', () => {

--- a/src/components/__tests__/MultiTickerChart.test.tsx
+++ b/src/components/__tests__/MultiTickerChart.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MultiTickerChart } from '../MultiTickerChart';
+import { createChart } from 'lightweight-charts';
+
+const mockSeries = {
+  setData: vi.fn(),
+  priceScale: vi.fn(() => ({ applyOptions: vi.fn() })),
+};
+
+const mockChart = {
+  addSeries: vi.fn(() => mockSeries),
+  timeScale: vi.fn(() => ({ fitContent: vi.fn() })),
+  remove: vi.fn(),
+};
+
+vi.mock('lightweight-charts', () => ({
+  createChart: vi.fn(() => mockChart),
+  createSeriesMarkers: vi.fn(() => ({ setMarkers: vi.fn() })),
+  CandlestickSeries: Symbol('CandlestickSeries'),
+  LineSeries: Symbol('LineSeries'),
+}));
+
+describe('MultiTickerChart', () => {
+  const tickersData = [
+    {
+      ticker: 'AAPL',
+      ibsValues: [],
+      data: [
+        { date: '2025-01-01', open: 100, high: 105, low: 98, close: 103, volume: 1000 },
+        { date: '2025-01-02', open: 103, high: 106, low: 102, close: 104, volume: 1200 },
+      ],
+    },
+    {
+      ticker: 'MSFT',
+      ibsValues: [],
+      data: [
+        { date: '2025-01-01', open: 200, high: 205, low: 198, close: 204, volume: 1400 },
+        { date: '2025-01-02', open: 204, high: 206, low: 201, close: 202, volume: 1500 },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders chart controls and initializes chart', () => {
+    render(<MultiTickerChart tickersData={tickersData} trades={[]} />);
+
+    expect(createChart).toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Candles' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Normalized (Base 100)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /AAPL/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /MSFT/ })).toBeInTheDocument();
+  });
+
+  it('switches to normalized mode', () => {
+    render(<MultiTickerChart tickersData={tickersData} trades={[]} />);
+
+    const before = (createChart as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    fireEvent.click(screen.getByRole('button', { name: 'Normalized (Base 100)' }));
+    const after = (createChart as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+
+    expect(after).toBeGreaterThan(before);
+  });
+});

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -1,38 +1,5 @@
 import type { ComponentType, SVGProps } from 'react';
 
-declare module 'lightweight-charts' {
-  export interface IPriceScaleApi {
-    applyOptions(options: Record<string, unknown>): void;
-  }
-
-  export interface ITimeScaleApi {
-    applyOptions(options: Record<string, unknown>): void;
-  }
-
-  export interface ISeriesApi<TSeriesType extends string = string> {
-    seriesType?: TSeriesType;
-    setData(data: Array<Record<string, unknown>>): void;
-    setMarkers?(markers: Array<Record<string, unknown>>): void;
-    priceScale(): IPriceScaleApi;
-    applyOptions?(options: Record<string, unknown>): void;
-  }
-
-  export interface IChartApi {
-    addCandlestickSeries(options?: Record<string, unknown>): ISeriesApi<'Candlestick'>;
-    addHistogramSeries(options?: Record<string, unknown>): ISeriesApi<'Histogram'>;
-    addLineSeries(options?: Record<string, unknown>): ISeriesApi<'Line'>;
-    remove(): void;
-    timeScale(): ITimeScaleApi;
-    applyOptions(options: Record<string, unknown>): void;
-    subscribeCrosshairMove(callback: (params: MouseEventParams) => void): () => void;
-  }
-
-  export type UTCTimestamp = number;
-  export type MouseEventParams = Record<string, unknown>;
-
-  export function createChart(container: HTMLElement, options?: Record<string, unknown>): IChartApi;
-}
-
 declare module 'lucide-react' {
   export type Icon = ComponentType<SVGProps<SVGSVGElement>>;
 


### PR DESCRIPTION
## Что сделано
- Миграция lightweight-charts с v4 на v5 (5.1.0)
- Перевод chart API на addSeries(...) и plugin markers (createSeriesMarkers)
- Исправление lifecycle: корректные subscribe/unsubscribe для crosshair
- Унификация time-conversion через toChartTimestamp(...)
- Удаление window.resize listeners в chart-компонентах, переход на autoSize
- Улучшения UX графиков:
  - диапазоны 1M/3M/6M/1Y/ALL для price/equity
  - режимы Candles / Normalized (Base 100) в multi-chart
  - ограничение и выбор видимых тикеров
- Исправления TS/типов и cleanup shim-типов lightweight-charts
- Добавлены/обновлены тесты графиков (MiniQuoteChart, MultiTickerChart)
- Обновлены документы:
  - LIGHTWEIGHT_CHARTS_DOCS_NOTES.md
  - STOCK_CHARTS_AUDIT.md

## Проверки
- npm run -s lint ✅
- npm run -s build:check ✅
- npm run -s test:run ✅ (325/325)

## Откат
- PR отдельный и атомарный: можно откатить через Revert PR/commit из main.
